### PR TITLE
Issue #2 - Critical Bug Fix: PostgreSQL 18 Volume Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ docker compose down
 ```
 
 Data is persisted in Docker volumes and will be available on next startup.
+
+## Updates
+
+- **2025-02-27 — PostgreSQL 18 volume path fix:** Changed the Postgres volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql` to match PG18's updated `PGDATA` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "5433:5432"              # Exposed on 5433 to avoid conflicts with a local Postgres on the default port
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     networks:
       - appnet
     healthcheck:                 # Other services wait on this check before starting


### PR DESCRIPTION
2025-02-27 — PostgreSQL 18 volume path fix:** Changed the Postgres volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql` to match PG18's updated `PGDATA` directory.