### PR TITLE
Issue: #4 -  Tier 2 — Operational Improvements (should-haves)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ docker compose run --rm init-script
 
 ```
 finance-stack/
-├── docker-compose.yml            # Infrastructure definition
+├── docker-compose.yml                    # Infrastructure definition
+├── .env.example                          # Template for credentials (copy to .env)
+├── init-db/
+│   └── 01-create-databases.sh            # First-run DB/role creation (auto-runs on empty data dir)
 └── scripts/
     └── UpdateAccountBalanceHistory.sql   # Balance history rebuild script
 ```
@@ -78,7 +81,7 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ### 2025-02-27
 
-**PostgreSQL 18 volume path fix**
+**Critical Bug Fix - PostgreSQL 18 volume path fix**
 Changed the Postgres volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql` to match PG18's updated `PGDATA` directory.
 
 **Tier 1 — Security and reliability hardening**
@@ -86,3 +89,9 @@ Changed the Postgres volume mount from `/var/lib/postgresql/data` to `/var/lib/p
 - Added `restart: unless-stopped` to long-running services
 - Metabase and Appsmith now wait for Postgres to be healthy before starting
 - Pinned all image tags: `postgres:18.0`, `metabase:v0.58.8`, `appsmith-ee:v1.87`
+
+**Tier 2 — Operational improvements**
+- Added healthchecks for Metabase and Appsmith so `docker compose ps` reports accurate status
+- Added log rotation (30 MB max per service) to prevent disk fills
+- Added `init-db/01-create-databases.sh` so the stack self-initializes on a fresh clone
+- Added memory and CPU resource limits to all services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,13 @@
 # postgres (data store), init-script (one-shot balance rebuild),
 # metabase (BI dashboards), and appsmith (internal app builder).
 
+# Shared logging config — keeps logs from filling the disk (30 MB max per service).
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
 
   # Primary PostgreSQL database that stores all financial data.
@@ -13,17 +20,29 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}           # Default system DB; the Finances DB is created by the backup restore
+      MB_DB_USER: ${MB_DB_USER}             # Passed through so init-db script can create the Metabase role
+      MB_DB_PASS: ${MB_DB_PASS}
+      MB_DB_DBNAME: ${MB_DB_DBNAME}
     ports:
       - "5433:5432"              # Exposed on 5433 to avoid conflicts with a local Postgres on the default port
     volumes:
       - postgres_data:/var/lib/postgresql  # PG18 moved PGDATA to /var/lib/postgresql/18/docker; mount the parent
+      - ./init-db:/docker-entrypoint-initdb.d:ro  # Runs once on first start (empty data dir) to create DBs and roles
     networks:
       - appnet
+    logging: *default-logging
     healthcheck:                 # Other services wait on this check before starting
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "1.0"
+        reservations:
+          memory: 256M
 
   # One-shot job: runs UpdateAccountBalanceHistory.sql after postgres is healthy,
   # then exits. Rebuilds the account_balance_history table with fresh cumulative balances.
@@ -43,6 +62,11 @@ services:
       bash -c "
       psql -h postgres -U ${POSTGRES_USER} -d ${INIT_SCRIPT_DB} -f /scripts/UpdateAccountBalanceHistory.sql
       "
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.5"
 
   # Metabase BI tool for dashboards and ad-hoc analytics against the Finances database.
   # Stores its own internal metadata (questions, dashboards, users) in a separate metabase DB.
@@ -67,6 +91,20 @@ services:
         condition: service_healthy  # Waits for postgres healthcheck, not just container start
     networks:
       - appnet
+    logging: *default-logging
+    healthcheck:                   # Metabase exposes a health API endpoint
+      test: ["CMD-SHELL", "curl --fail -I http://localhost:3000/api/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 120s          # Metabase can take 1-2 min on first startup (DB migrations)
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "1.0"
+        reservations:
+          memory: 512M
 
   # Appsmith Enterprise Edition — low-code platform for building internal financial apps.
   appsmith:
@@ -82,6 +120,20 @@ services:
         condition: service_healthy  # Waits for postgres healthcheck, not just container start
     networks:
       - appnet
+    logging: *default-logging
+    healthcheck:                   # Appsmith ships a built-in healthcheck script
+      test: ["CMD-SHELL", "/opt/appsmith/healthcheck.sh"]
+      interval: 15s
+      timeout: 15s
+      retries: 3
+      start_period: 120s          # Appsmith can take up to 2 min on first start
+    deploy:
+      resources:
+        limits:
+          memory: 3G              # Appsmith idles near 2 GB; 3 GB gives headroom under load
+          cpus: "1.0"
+        reservations:
+          memory: 512M
 
 volumes:
   postgres_data:    # Persists PostgreSQL data across container restarts

--- a/init-db/01-create-databases.sh
+++ b/init-db/01-create-databases.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# ------------------------------------------------------------
+# First-run database initialization for the finance stack.
+#
+# This script is mounted into /docker-entrypoint-initdb.d/ and
+# runs automatically the first time Postgres starts with an
+# empty data directory. It is skipped on subsequent starts.
+#
+# It creates:
+#   1. The "Finances" database (the main application database)
+#   2. The Metabase role and database (for Metabase internal metadata)
+#
+# All credentials are read from environment variables passed
+# through docker-compose.yml (sourced from .env).
+# ------------------------------------------------------------
+set -euo pipefail
+
+echo ">>> Creating Finances database..."
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    SELECT 'CREATE DATABASE "Finances"'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'Finances')\gexec
+EOSQL
+
+echo ">>> Creating Metabase role and database..."
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    DO \$\$
+    BEGIN
+      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${MB_DB_USER}') THEN
+        CREATE ROLE ${MB_DB_USER} WITH LOGIN PASSWORD '${MB_DB_PASS}';
+      END IF;
+    END
+    \$\$;
+
+    SELECT 'CREATE DATABASE ${MB_DB_DBNAME} OWNER ${MB_DB_USER}'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${MB_DB_DBNAME}')\gexec
+
+    GRANT ALL PRIVILEGES ON DATABASE ${MB_DB_DBNAME} TO ${MB_DB_USER};
+EOSQL
+
+echo ">>> Database initialization complete."


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Tier 2 is complete. Here's what changed:</p>

Change | Details
-- | --
Healthchecks | Metabase uses /api/health endpoint, Appsmith uses its built-in healthcheck.sh. Both have 120s start periods. All three services now report (healthy) in docker compose ps.
Log rotation | Shared x-logging YAML anchor applied to postgres, metabase, and appsmith — 10 MB per file, 3 files max (30 MB cap per service).
DB initialization | init-db/01-create-databases.sh auto-creates the Finances DB and metabase user/DB on first start. Safe for existing volumes (only runs on empty data dir).
Resource limits | Postgres 1G, Metabase 2G, Appsmith 3G (bumped from 2G after observing ~2 GB idle usage), init-script 512M.


<p><strong>Files created:</strong> <code>init-db/01-create-databases.sh</code>
<strong>Files modified:</strong> <code>docker-compose.yml</code>, <code>README.md</code></p></body></html><!--EndFragment-->
</body>
</html>