### PR TITLE
Issue: #5 - Tier 3 — Developer Experience (nice-to-haves)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Version control
+.git
+
+# IDE and tooling
+.vs
+.claude
+
+# Credentials
+.env
+secrets/
+
+# Documentation
+*.md

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ docker compose up
 
 This will:
 1. Start PostgreSQL and wait until it is healthy
-2. Run `UpdateAccountBalanceHistory.sql` to rebuild daily cumulative balances
-3. Start Metabase and Appsmith
+2. Start Metabase and Appsmith
 
 ### 2. Access the services
 
@@ -51,10 +50,10 @@ This will:
 
 `account_balance_history` is rebuilt automatically every time the stack starts via the `init-script` service. It calculates a running cumulative balance for each account for every calendar day, filling in days with no transactions with a zero daily change.
 
-To run it manually:
+The init-script is behind a profile and does not run automatically. To run it:
 
 ```bash
-docker compose run --rm init-script
+docker compose --profile init run --rm init-script
 ```
 
 ## Project Structure
@@ -63,6 +62,7 @@ docker compose run --rm init-script
 finance-stack/
 ├── docker-compose.yml                    # Infrastructure definition
 ├── .env.example                          # Template for credentials (copy to .env)
+├── .dockerignore                         # Excludes files from Docker build context
 ├── init-db/
 │   └── 01-create-databases.sh            # First-run DB/role creation (auto-runs on empty data dir)
 └── scripts/
@@ -95,3 +95,10 @@ Changed the Postgres volume mount from `/var/lib/postgresql/data` to `/var/lib/p
 - Added log rotation (30 MB max per service) to prevent disk fills
 - Added `init-db/01-create-databases.sh` so the stack self-initializes on a fresh clone
 - Added memory and CPU resource limits to all services
+
+**Tier 3 — Developer experience**
+- Init-script moved behind `profiles: ["init"]` — no longer runs on every `docker compose up`
+- Hardened init-script entrypoint with `set -euo pipefail`, retry loop, and read-only script mount
+- Added `name: finance-stack` for consistent container/volume naming
+- Added labels to all services for filtering with `docker ps --filter`
+- Created `.dockerignore`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@
 # postgres (data store), init-script (one-shot balance rebuild),
 # metabase (BI dashboards), and appsmith (internal app builder).
 
+name: finance-stack                    # Ensures consistent container/volume naming regardless of directory
+
 # Shared logging config — keeps logs from filling the disk (30 MB max per service).
 x-logging: &default-logging
   driver: "json-file"
@@ -43,30 +45,50 @@ services:
           cpus: "1.0"
         reservations:
           memory: 256M
+    labels:
+      com.finance-stack.component: "database"
+      com.finance-stack.description: "Primary PostgreSQL database"
 
   # One-shot job: runs UpdateAccountBalanceHistory.sql after postgres is healthy,
   # then exits. Rebuilds the account_balance_history table with fresh cumulative balances.
+  # Behind the "init" profile — only runs when explicitly requested:
+  #   docker compose --profile init run --rm init-script
   init-script:
     image: postgres:18.0
+    profiles: ["init"]                   # Not started by default; run with --profile init
     restart: "no"                        # One-shot job — must not restart after exiting
     depends_on:
       postgres:
         condition: service_healthy  # Waits for postgres to pass its healthcheck before running
     networks:
       - appnet
-    environment:                         # Password passed via env var instead of inline in the entrypoint
+    environment:                         # Credentials via env vars; PGHOST/PGUSER/PGDATABASE are native psql vars
       PGPASSWORD: ${POSTGRES_PASSWORD}
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER}
+      PGDATABASE: ${INIT_SCRIPT_DB:-Finances}
     volumes:
-      - ./scripts:/scripts          # Only this container mounts the scripts directory
+      - ./scripts:/scripts:ro            # Read-only mount — container should not modify scripts
     entrypoint: >
       bash -c "
-      psql -h postgres -U ${POSTGRES_USER} -d ${INIT_SCRIPT_DB} -f /scripts/UpdateAccountBalanceHistory.sql
+      set -euo pipefail;
+      echo 'Waiting for $${PGDATABASE} database...';
+      until psql -c 'SELECT 1' > /dev/null 2>&1; do
+        echo 'Database not ready, retrying in 2s...';
+        sleep 2;
+      done;
+      echo 'Running UpdateAccountBalanceHistory.sql...';
+      psql -f /scripts/UpdateAccountBalanceHistory.sql;
+      echo 'Done.';
       "
     deploy:
       resources:
         limits:
           memory: 512M
           cpus: "0.5"
+    labels:
+      com.finance-stack.component: "init"
+      com.finance-stack.description: "One-shot balance history rebuild"
 
   # Metabase BI tool for dashboards and ad-hoc analytics against the Finances database.
   # Stores its own internal metadata (questions, dashboards, users) in a separate metabase DB.
@@ -105,6 +127,9 @@ services:
           cpus: "1.0"
         reservations:
           memory: 512M
+    labels:
+      com.finance-stack.component: "bi"
+      com.finance-stack.description: "Metabase BI dashboards"
 
   # Appsmith Enterprise Edition — low-code platform for building internal financial apps.
   appsmith:
@@ -134,6 +159,9 @@ services:
           cpus: "1.0"
         reservations:
           memory: 512M
+    labels:
+      com.finance-stack.component: "app-builder"
+      com.finance-stack.description: "Appsmith low-code platform"
 
 volumes:
   postgres_data:    # Persists PostgreSQL data across container restarts


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Tier 3 is complete. Here's what changed:</p>

Change | Details
-- | --
Init-script profiled | Behind profiles: ["init"] — no longer runs on every docker compose up. Run manually with docker compose --profile init run --rm init-script
Init-script hardened | set -euo pipefail, retry loop waiting for the database, native Postgres env vars (PGHOST/PGUSER/PGDATABASE), read-only script mount (:ro)
Project name | name: finance-stack ensures consistent naming regardless of directory
Labels | All services tagged with com.finance-stack.component and com.finance-stack.description — filterable via docker ps --filter
.dockerignore | Excludes .git, .vs, .claude, .env, secrets/, *.md from any future build contexts


<p><strong>Files created:</strong> <code>.dockerignore</code>
<strong>Files modified:</strong> <code>docker-compose.yml</code>, <code>README.md</code></p>
</body>
</html>