### PR TITLE
Issue #27 and #28

### DIFF
--- a/app/app/transactions/new/actions.ts
+++ b/app/app/transactions/new/actions.ts
@@ -1,6 +1,10 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
+import { db } from "@/lib/db";
+import { transactions } from "@/drizzle/schema";
 import { transactionFormSchema } from "@/lib/validations/transaction";
+import { rebuildAccountBalance } from "@/lib/queries/rebuild-balance";
 
 export async function submitTransaction(
   prevState: { success: boolean; errors: Record<string, string[]>; message: string },
@@ -29,10 +33,41 @@ export async function submitTransaction(
     return { success: false, errors: fieldErrors, message: "Validation failed" };
   }
 
-  // TODO: Issue #27 — Replace with actual DB insert via Drizzle
-  // TODO: Issue #28 — Trigger per-account balance history rebuild
-  // TODO: revalidatePath("/dashboard")
-  // TODO: revalidatePath("/accounts")
+  const data = result.data;
+  const accountId = Number(data.accountId);
+  const relatedAccountId = data.relatedAccountId
+    ? Number(data.relatedAccountId)
+    : null;
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx.insert(transactions).values({
+        transactionDescription: data.transactionDescription,
+        transactionDate: data.transactionDate,
+        accountId,
+        amount: data.amount,
+        relatedAccountId,
+        transactionTypeId: Number(data.transactionTypeId),
+        transactionCategoryId: Number(data.transactionCategoryId),
+      });
+
+      await rebuildAccountBalance(tx, accountId);
+
+      if (relatedAccountId) {
+        await rebuildAccountBalance(tx, relatedAccountId);
+      }
+    });
+  } catch (error) {
+    console.error("Transaction insert failed:", error);
+    return {
+      success: false,
+      errors: {},
+      message: "Failed to save transaction. Please try again.",
+    };
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath("/accounts");
 
   return {
     success: true,

--- a/app/lib/queries/rebuild-balance.ts
+++ b/app/lib/queries/rebuild-balance.ts
@@ -1,0 +1,73 @@
+import { sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+
+/**
+ * Rebuilds account_balance_history rows for a single account.
+ *
+ * Scoped version of scripts/UpdateAccountBalanceHistory.sql.
+ * Generates a date series from the account's earliest transaction
+ * through today, aggregates daily balances, computes cumulative
+ * totals, and upserts into account_balance_history.
+ *
+ * Designed to run inside an existing Drizzle transaction.
+ */
+export async function rebuildAccountBalance(
+  tx: NodePgDatabase<any>,
+  accountId: number
+): Promise<void> {
+  await tx.execute(sql`
+    WITH date_series AS (
+      SELECT generate_series(
+        (SELECT MIN(DATE(transaction_date)) FROM transactions WHERE account_id = ${accountId}),
+        CURRENT_DATE,
+        INTERVAL '1 day'
+      )::DATE AS balance_date
+    ),
+    account_dates AS (
+      SELECT a.account_id, d.balance_date
+      FROM accounts a
+      CROSS JOIN date_series d
+      WHERE a.account_id = ${accountId}
+        AND (a.opened_date IS NULL OR a.opened_date <= d.balance_date)
+        AND (a.closed_date IS NULL OR a.closed_date > d.balance_date)
+    ),
+    daily_transactions AS (
+      SELECT
+        account_id,
+        DATE(transaction_date) AS balance_date,
+        SUM(amount) AS daily_balance
+      FROM transactions
+      WHERE account_id = ${accountId}
+      GROUP BY account_id, DATE(transaction_date)
+    ),
+    daily_with_zeros AS (
+      SELECT
+        ad.account_id,
+        ad.balance_date,
+        COALESCE(dt.daily_balance, 0) AS daily_balance
+      FROM account_dates ad
+      LEFT JOIN daily_transactions dt
+        ON ad.account_id = dt.account_id
+       AND ad.balance_date = dt.balance_date
+    ),
+    final_balances AS (
+      SELECT
+        account_id,
+        balance_date,
+        daily_balance,
+        SUM(daily_balance) OVER (
+          PARTITION BY account_id
+          ORDER BY balance_date
+          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS cumulative_balance
+      FROM daily_with_zeros
+    )
+    INSERT INTO account_balance_history (account_id, balance_date, daily_balance, cumulative_balance)
+    SELECT account_id, balance_date, daily_balance, cumulative_balance
+    FROM final_balances
+    ON CONFLICT (account_id, balance_date)
+    DO UPDATE
+    SET daily_balance = EXCLUDED.daily_balance,
+        cumulative_balance = EXCLUDED.cumulative_balance
+  `);
+}


### PR DESCRIPTION
Implementation complete. Here's what was done:

**New file: `app/lib/queries/rebuild-balance.ts`**
- Exports `rebuildAccountBalance(tx, accountId)` — scoped version of the full rebuild CTE
- Filters all three CTE stages (`date_series`, `account_dates`, `daily_transactions`) by `account_id`
- Uses parameterized `sql` template tag (prevents SQL injection)
- Upserts via `ON CONFLICT ... DO UPDATE` (same pattern as original script)

**Modified file: `app/app/transactions/new/actions.ts`**
- Replaced the stub TODO block with a `db.transaction()` call that:
  1. Inserts into `transactions` table via Drizzle
  2. Rebuilds balance history for the primary account
  3. Rebuilds balance history for the related account (if present)
- `amount` stays as string through to the insert (avoids floating-point loss)
- On DB error: logs full error server-side, returns generic user-facing message, transaction is rolled back
- On success: calls `revalidatePath("/dashboard")` and `revalidatePath("/accounts")`

Both `tsc --noEmit` and `npm run build` pass cleanly.