### PR TITLE
Issue #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,15 @@ finance-stack/
 │   │   ├── ui/                           # shadcn/ui components (Button, Card, Table, Dialog, etc.)
 │   │   │   └── date-range-picker.tsx     # Date range picker with quick select + manual input
 │   │   ├── charts/                       # Chart components (client components)
+│   │   │   ├── accounting-chart.tsx      # Time-series area chart for income/expenses/investments (Chart.js)
+│   │   │   ├── expenses-category-chart.tsx # Donut chart for expense category breakdown (Chart.js)
 │   │   │   ├── net-worth-chart.tsx       # Reusable time-series line chart (Recharts)
 │   │   │   └── gauge-badge.tsx           # Custom SVG semicircular gauge with range segments
 │   │   ├── accounts/                     # Accounts page components
 │   │   │   └── accounts-table.tsx        # Two-column balance sheet with expand/collapse; exports amountColorClass()
 │   │   ├── dashboard/                    # Dashboard-specific components
+│   │   │   ├── accounting-filters.tsx    # Multi-select combobox filters for accounting page
+│   │   │   ├── accounting-kpi-card.tsx   # KPI card with change indicator for accounting metrics
 │   │   │   └── date-range-filter.tsx     # URL-param-driven date range filter wrapper
 │   │   └── transactions/                 # Transaction-specific components
 │   │       ├── transaction-form.tsx      # Transaction entry form (client component)
@@ -225,6 +229,7 @@ finance-stack/
 │       ├── db/index.ts                   # Drizzle ORM client (PostgreSQL connection)
 │       ├── actions/transaction.ts        # Server action for transaction submission
 │       ├── queries/accounts.ts           # Account balance queries (ROLLUP aggregation)
+│       ├── queries/accounting.ts         # Accounting queries (time series, period totals, category breakdown, averages)
 │       ├── queries/dashboard.ts          # Dashboard queries (net worth, time series)
 │       ├── queries/rebuild-balance.ts    # Per-account balance history rebuild
 │       ├── queries/transactions.ts       # Transaction queries (filtered, sorted, form options)
@@ -247,6 +252,20 @@ docker compose down
 Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
+
+### 2026-03-20
+
+**Personal Accounting dashboard (Issue #33)**
+- Built the Personal Accounting tab with interactive filters, time-series chart, expense category breakdown, and KPI cards
+- 5 server-side queries run in parallel: time series, period totals, to-date comparison, category breakdown, and 12-month rolling averages
+- Filters: date range, description (multi-select), account (multi-select), category (multi-select), and time grouping (11 options including day-of-week, month-of-year, etc.)
+- All filter state stored in URL search params for shareable/bookmarkable views
+- Time-series area chart (Chart.js) with toggleable legend and smart date formatting per grouping type
+- Donut chart showing top 10 expense categories with "Other" rollup and center total label
+- 9 KPI cards across 3 columns (Income, Expenses, Investments): to-date totals with period-over-period change, period totals, and 12-month averages
+- Color-coded change indicators (green/red) based on metric direction (up is good for income, down is good for expenses)
+- Chip overflow on multi-select filters: max 2 chips shown with "+N more" badge and hover tooltip
+- New query module at `lib/queries/accounting.ts` with raw SQL for `generate_series`, `date_trunc`, and `EXTRACT` operations
 
 ### 2026-03-16
 

--- a/app/app/dashboard/accounting/page.tsx
+++ b/app/app/dashboard/accounting/page.tsx
@@ -1,11 +1,357 @@
-// /dashboard/accounting — Personal accounting tab.
-// Will display income vs. expenses breakdown, category spending,
-// and monthly trends. Implementation tracked in Issue #33.
+import {
+  getAccountingTimeSeries,
+  getAccountingPeriodTotals,
+  getAccountingToDateComparison,
+  getExpenseCategoryBreakdown,
+  getAccountingMonthlyAverages,
+  isStandardGrouping,
+  type AccountingFilters,
+  type TimeGrouping,
+} from "@/lib/queries/accounting";
+import {
+  getTransactionFormOptions,
+  getUniqueDescriptions,
+} from "@/lib/queries/transactions";
+import { AccountingChart } from "@/components/charts/accounting-chart";
+import { ExpensesCategoryChart } from "@/components/charts/expenses-category-chart";
+import { AccountingKpiCard } from "@/components/dashboard/accounting-kpi-card";
+import { AccountingFilters as AccountingFiltersUI } from "@/components/dashboard/accounting-filters";
 
-export default function AccountingPage() {
+export const dynamic = "force-dynamic";
+
+const TIME_GROUPING_LABELS: Record<string, string> = {
+  day: "Daily",
+  week: "Weekly",
+  month: "Monthly",
+  quarter: "Quarterly",
+  year: "Yearly",
+  day_of_week: "By Day of Week",
+  day_of_month: "By Day of Month",
+  day_of_year: "By Day of Year",
+  week_of_year: "By Week of Year",
+  month_of_year: "By Month of Year",
+  quarter_of_year: "By Quarter of Year",
+};
+
+function FilterSegment({ label, values, maxVisible = 2 }: { label: string; values: string[]; maxVisible?: number }) {
+  if (values.length === 0) return null;
+  const visible = values.slice(0, maxVisible);
+  const overflow = values.length - visible.length;
   return (
-    <p className="text-zinc-600 dark:text-zinc-400">
-      Personal accounting coming soon.
-    </p>
+    <span className="shrink-0">
+      <span className="font-medium text-foreground/70">{label}:</span>{" "}
+      {visible.join(", ")}
+      {overflow > 0 && (
+        <span
+          className="cursor-default underline decoration-dotted"
+          title={values.join("\n")}
+        >
+          {" "}+{overflow} more
+        </span>
+      )}
+    </span>
+  );
+}
+
+function FilterIndicator({
+  filters,
+  accounts,
+  categories,
+  includeGrouping,
+}: {
+  filters: AccountingFilters;
+  accounts: { id: number; name: string }[];
+  categories: { id: number; name: string }[];
+  includeGrouping?: boolean;
+}) {
+  const fromDate = filters.dateFrom ? new Date(filters.dateFrom + "T00:00:00") : undefined;
+  const toDate = filters.dateTo ? new Date(filters.dateTo + "T00:00:00") : undefined;
+  const fmt = (d: Date) => d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  const dateLabel = fromDate
+    ? toDate ? `${fmt(fromDate)} – ${fmt(toDate)}` : `${fmt(fromDate)} – Present`
+    : undefined;
+
+  const descNames = filters.descriptions ?? [];
+  const accountNames = (filters.accountIds ?? []).map(id => accounts.find(a => a.id === id)?.name ?? String(id));
+  const categoryNames = (filters.categoryIds ?? []).map(id => categories.find(c => c.id === id)?.name ?? String(id));
+
+  const hasFilters = includeGrouping || dateLabel || descNames.length || accountNames.length || categoryNames.length;
+  if (!hasFilters) return null;
+
+  return (
+    <div className="flex min-w-0 max-w-full items-center gap-x-3 overflow-hidden text-[11px] text-muted-foreground whitespace-nowrap">
+      {includeGrouping && filters.timeGrouping && (
+        <span className="shrink-0">
+          <span className="font-medium text-foreground/70">Grouped:</span>{" "}
+          {TIME_GROUPING_LABELS[filters.timeGrouping] ?? filters.timeGrouping}
+        </span>
+      )}
+      {dateLabel && (
+        <span className="shrink-0">
+          <span className="font-medium text-foreground/70">Period:</span>{" "}
+          {dateLabel}
+        </span>
+      )}
+      <FilterSegment label="Descriptions" values={descNames} />
+      <FilterSegment label="Accounts" values={accountNames} maxVisible={3} />
+      <FilterSegment label="Categories" values={categoryNames} />
+    </div>
+  );
+}
+
+const VALID_GROUPINGS: TimeGrouping[] = [
+  "day", "week", "month", "quarter", "year",
+  "day_of_week", "day_of_month", "day_of_year",
+  "week_of_year", "month_of_year", "quarter_of_year",
+];
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(n);
+
+function computeChange(
+  current: number,
+  previous: number,
+  prevLabel: string
+): {
+  percent: number;
+  direction: "up" | "down" | "none";
+  label: string;
+} {
+  if (previous === 0 && current === 0) {
+    return { percent: 0, direction: "none", label: `vs. ${prevLabel}` };
+  }
+  if (previous === 0) {
+    return { percent: 100, direction: "up", label: `vs. ${prevLabel}: ${formatCurrency(previous)}` };
+  }
+  const pct = ((current - previous) / previous) * 100;
+  if (pct === 0) {
+    return { percent: 0, direction: "none", label: `vs. ${prevLabel}` };
+  }
+  return {
+    percent: Math.abs(pct),
+    direction: pct > 0 ? "up" : "down",
+    label: `vs. ${prevLabel}: ${formatCurrency(previous)}`,
+  };
+}
+
+function parseSearchParams(
+  params: Record<string, string | string[] | undefined>
+): AccountingFilters & { rawFilters: Record<string, string | string[] | number[] | undefined> } {
+  const get = (key: string): string | undefined => {
+    const val = params[key];
+    if (Array.isArray(val)) return val[0];
+    return val || undefined;
+  };
+
+  const getNumberArray = (key: string): number[] | undefined => {
+    const raw = get(key);
+    if (!raw) return undefined;
+    const nums = raw.split(",").map(Number).filter((n) => !isNaN(n));
+    return nums.length > 0 ? nums : undefined;
+  };
+
+  const getStringArray = (key: string): string[] | undefined => {
+    const raw = get(key);
+    if (!raw) return undefined;
+    const items = raw.split(",").filter(Boolean);
+    return items.length > 0 ? items : undefined;
+  };
+
+  // Default to last 30 days
+  const defaultFrom = new Date();
+  defaultFrom.setDate(defaultFrom.getDate() - 30);
+  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
+
+  const dateFrom = get("dateFrom") || defaultFromStr;
+  const dateTo = get("dateTo") || undefined;
+  const descriptions = getStringArray("descriptions");
+  const accountIds = getNumberArray("accountIds");
+  const categoryIds = getNumberArray("categoryIds");
+  const rawGrouping = get("timeGrouping");
+  const timeGrouping: TimeGrouping = VALID_GROUPINGS.includes(rawGrouping as TimeGrouping)
+    ? (rawGrouping as TimeGrouping)
+    : "month";
+
+  return {
+    dateFrom,
+    dateTo,
+    descriptions,
+    accountIds,
+    categoryIds,
+    timeGrouping,
+    rawFilters: {
+      dateFrom: get("dateFrom"),
+      dateTo: get("dateTo"),
+      descriptions,
+      accountIds,
+      categoryIds,
+      timeGrouping: rawGrouping,
+    },
+  };
+}
+
+export default async function AccountingPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const resolvedParams = await searchParams;
+  const { rawFilters, ...filters } = parseSearchParams(resolvedParams);
+
+  const showToDate = isStandardGrouping(filters.timeGrouping ?? "month");
+
+  const [
+    timeSeries,
+    periodTotals,
+    toDate,
+    categoryBreakdown,
+    averages,
+    { accounts, categories },
+    descriptions,
+  ] = await Promise.all([
+    getAccountingTimeSeries(filters),
+    getAccountingPeriodTotals(filters),
+    showToDate ? getAccountingToDateComparison(filters) : Promise.resolve(null),
+    getExpenseCategoryBreakdown(filters),
+    getAccountingMonthlyAverages(filters),
+    getTransactionFormOptions(),
+    getUniqueDescriptions(),
+  ]);
+
+  const incomeChange = toDate ? computeChange(
+    toDate.currentIncome,
+    toDate.previousIncome,
+    toDate.previousMonthLabel
+  ) : undefined;
+  const expenseChange = toDate ? computeChange(
+    toDate.currentExpenses,
+    toDate.previousExpenses,
+    toDate.previousMonthLabel
+  ) : undefined;
+  const investmentChange = toDate ? computeChange(
+    toDate.currentInvestments,
+    toDate.previousInvestments,
+    toDate.previousMonthLabel
+  ) : undefined;
+
+  const chartIndicator = <FilterIndicator filters={filters} accounts={accounts} categories={categories} includeGrouping />;
+  const kpiIndicator = <FilterIndicator filters={filters} accounts={accounts} categories={categories} />;
+
+  return (
+    <div className="space-y-6">
+      {/* ── Page Title & Filters ── */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Personal Accounting Overview</h1>
+        <div className="mt-3">
+          <AccountingFiltersUI
+            descriptions={descriptions}
+            accounts={accounts}
+            categories={categories}
+            filters={rawFilters as Record<string, string | string[] | number[] | undefined> & {
+              dateFrom?: string;
+              dateTo?: string;
+              descriptions?: string[];
+              accountIds?: number[];
+              categoryIds?: number[];
+              timeGrouping?: string;
+            }}
+          />
+        </div>
+      </div>
+
+      {/* ── Charts Row ── */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        <AccountingChart data={timeSeries} timeGrouping={filters.timeGrouping} description={chartIndicator} />
+        <ExpensesCategoryChart data={categoryBreakdown} description={kpiIndicator} />
+      </div>
+
+      {/* ── KPI Cards: Income / Expenses / Investments ── */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Income column */}
+        <div className="min-w-0 space-y-4">
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold">Income</h2>
+            {kpiIndicator}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {toDate && (
+              <AccountingKpiCard
+                title="Total Income to Date"
+                value={formatCurrency(toDate.currentIncome)}
+                subtitle={toDate.currentMonthLabel}
+                change={incomeChange}
+                positiveDirection="up"
+              />
+            )}
+            <AccountingKpiCard
+              title="Total Income in Time Period"
+              value={formatCurrency(periodTotals.totalIncome)}
+            />
+          </div>
+          <AccountingKpiCard
+            title="Average Income per Month - Last 12 Months"
+            value={formatCurrency(averages.totalIncome)}
+          />
+        </div>
+
+        {/* Expenses column */}
+        <div className="min-w-0 space-y-4">
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold">Expenses</h2>
+            {kpiIndicator}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {toDate && (
+              <AccountingKpiCard
+                title="Total Expenses to Date"
+                value={formatCurrency(toDate.currentExpenses)}
+                subtitle={toDate.currentMonthLabel}
+                change={expenseChange}
+                positiveDirection="down"
+              />
+            )}
+            <AccountingKpiCard
+              title="Total Expenses in Time Period"
+              value={formatCurrency(periodTotals.totalExpenses)}
+            />
+          </div>
+          <AccountingKpiCard
+            title="Average Expenses per Month - Last 12 Months"
+            value={formatCurrency(averages.totalExpenses)}
+          />
+        </div>
+
+        {/* Investments column */}
+        <div className="min-w-0 space-y-4">
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold">Investments</h2>
+            {kpiIndicator}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {toDate && (
+              <AccountingKpiCard
+                title="Total Investments to Date"
+                value={formatCurrency(toDate.currentInvestments)}
+                subtitle={toDate.currentMonthLabel}
+                change={investmentChange}
+                positiveDirection="up"
+              />
+            )}
+            <AccountingKpiCard
+              title="Total Investments in Time Period"
+              value={formatCurrency(periodTotals.totalInvestments)}
+            />
+          </div>
+          <AccountingKpiCard
+            title="Average Investments per Month - Last 12 Months"
+            value={formatCurrency(averages.totalInvestments)}
+          />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/app/components/charts/accounting-chart.tsx
+++ b/app/components/charts/accounting-chart.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import type React from "react";
+import { useState } from "react";
+import { addDays, format, getQuarter } from "date-fns";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { AccountingTimeSeriesPoint, TimeGrouping } from "@/lib/queries/accounting";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const COLORS = {
+  income: "#2eb88a",
+  expenses: "#2662d9",
+  investments: "#e23670",
+};
+
+const METRIC_KEYS = ["totalIncome", "totalExpenses", "totalInvestments"] as const;
+
+const chartConfig: ChartConfig = {
+  totalIncome: { label: "Total Income", color: COLORS.income },
+  totalExpenses: { label: "Total Expenses", color: COLORS.expenses },
+  totalInvestments: { label: "Total Investments", color: COLORS.investments },
+};
+
+const TOOLTIP_LABELS: Record<string, string> = {
+  totalIncome: "Income:",
+  totalExpenses: "Expenses:",
+  totalInvestments: "Investments:",
+};
+
+const formatCurrencyCompact = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+
+const formatCurrencyFull = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const DOW_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTH_NAMES = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function parseDate(dateStr: string) {
+  return new Date(dateStr + "T00:00:00");
+}
+
+function formatDotDate(d: Date) {
+  return `${d.getMonth() + 1}.${d.getDate()}.${d.getFullYear()}`;
+}
+
+function makeTickFormatter(grouping: TimeGrouping) {
+  if (grouping === "day") {
+    return (dateStr: string) => format(parseDate(dateStr), "MMM d");
+  }
+  if (grouping === "week") {
+    // Show last day of week period
+    return (dateStr: string) => {
+      const end = addDays(parseDate(dateStr), 6);
+      return format(end, "MMM d");
+    };
+  }
+  if (grouping === "month") {
+    return (dateStr: string) => format(parseDate(dateStr), "MMMM yyyy");
+  }
+  if (grouping === "quarter") {
+    return (dateStr: string) => {
+      const d = parseDate(dateStr);
+      return `Q${getQuarter(d)} ${d.getFullYear()}`;
+    };
+  }
+  if (grouping === "year") {
+    return (dateStr: string) => format(parseDate(dateStr), "yyyy");
+  }
+  if (grouping === "day_of_week") {
+    return (val: string) => DOW_NAMES[Number(val)] ?? val;
+  }
+  if (grouping === "month_of_year") {
+    return (val: string) => MONTH_NAMES[Number(val)] ?? val;
+  }
+  if (grouping === "quarter_of_year") {
+    return (val: string) => `Q${val}`;
+  }
+  // day_of_month, day_of_year, week_of_year — just show the number
+  return (val: string) => val;
+}
+
+function makeTooltipLabelFormatter(grouping: TimeGrouping) {
+  if (grouping === "day") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) => {
+      if (!payload?.[0]?.payload?.date) return "";
+      return format(parseDate(payload[0].payload.date), "MMM d, yyyy");
+    };
+  }
+  if (grouping === "week") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) => {
+      if (!payload?.[0]?.payload?.date) return "";
+      const start = parseDate(payload[0].payload.date);
+      const end = addDays(start, 6);
+      return `${formatDotDate(start)} - ${formatDotDate(end)}`;
+    };
+  }
+  if (grouping === "month") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) => {
+      if (!payload?.[0]?.payload?.date) return "";
+      return format(parseDate(payload[0].payload.date), "MMMM yyyy");
+    };
+  }
+  if (grouping === "quarter") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) => {
+      if (!payload?.[0]?.payload?.date) return "";
+      const d = parseDate(payload[0].payload.date);
+      return `Q${getQuarter(d)} ${d.getFullYear()}`;
+    };
+  }
+  if (grouping === "year") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) => {
+      if (!payload?.[0]?.payload?.date) return "";
+      return format(parseDate(payload[0].payload.date), "yyyy");
+    };
+  }
+  if (grouping === "day_of_week") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) =>
+      DOW_NAMES[Number(payload?.[0]?.payload?.date)] ?? String(payload?.[0]?.payload?.date);
+  }
+  if (grouping === "month_of_year") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) =>
+      MONTH_NAMES[Number(payload?.[0]?.payload?.date)] ?? String(payload?.[0]?.payload?.date);
+  }
+  if (grouping === "quarter_of_year") {
+    return (_: unknown, payload: Array<{ payload?: { date?: string } }>) =>
+      `Q${payload?.[0]?.payload?.date}`;
+  }
+  return (_: unknown, payload: Array<{ payload?: { date?: string } }>) =>
+    String(payload?.[0]?.payload?.date ?? "");
+}
+
+interface AccountingChartProps {
+  data: AccountingTimeSeriesPoint[];
+  timeGrouping?: TimeGrouping;
+  description?: React.ReactNode;
+}
+
+export function AccountingChart({ data, timeGrouping = "month", description }: AccountingChartProps) {
+  const [visibleMetrics, setVisibleMetrics] = useState<Set<string>>(
+    () => new Set(METRIC_KEYS)
+  );
+  const tickFormatter = makeTickFormatter(timeGrouping);
+  const tooltipLabelFormatter = makeTooltipLabelFormatter(timeGrouping);
+
+  const toggleMetric = (key: string) => {
+    setVisibleMetrics((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        // Don't allow toggling off the last metric
+        if (next.size > 1) next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Totals Over Time</CardTitle>
+        {description && <div className="mt-1">{description}</div>}
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="aspect-[5/2] w-full">
+          <AreaChart data={data} margin={{ left: 8, right: 8, bottom: 0 }}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickFormatter={tickFormatter}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={32}
+            />
+            <YAxis
+              tickFormatter={formatCurrencyCompact}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              width={60}
+              domain={["auto", "auto"]}
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  labelFormatter={tooltipLabelFormatter}
+                  labelClassName="font-bold"
+                  formatter={(value, name) => (
+                    <div className="flex flex-1 justify-between gap-4">
+                      <span className="font-bold">
+                        {TOOLTIP_LABELS[name as string] ?? name}
+                      </span>
+                      <span className="tabular-nums">
+                        {formatCurrencyFull(value as number)}
+                      </span>
+                    </div>
+                  )}
+                />
+              }
+            />
+            {visibleMetrics.has("totalIncome") && (
+              <Area
+                type="monotone"
+                dataKey="totalIncome"
+                stroke={COLORS.income}
+                fill={COLORS.income}
+                fillOpacity={0.15}
+                strokeWidth={2}
+              />
+            )}
+            {visibleMetrics.has("totalExpenses") && (
+              <Area
+                type="monotone"
+                dataKey="totalExpenses"
+                stroke={COLORS.expenses}
+                fill={COLORS.expenses}
+                fillOpacity={0.15}
+                strokeWidth={2}
+              />
+            )}
+            {visibleMetrics.has("totalInvestments") && (
+              <Area
+                type="monotone"
+                dataKey="totalInvestments"
+                stroke={COLORS.investments}
+                fill={COLORS.investments}
+                fillOpacity={0.15}
+                strokeWidth={2}
+              />
+            )}
+          </AreaChart>
+        </ChartContainer>
+        {/* Clickable Legend */}
+        <div className="flex items-center justify-center gap-4 pt-3 text-xs">
+          {METRIC_KEYS.map((key) => {
+            const active = visibleMetrics.has(key);
+            const color = key === "totalIncome" ? COLORS.income : key === "totalExpenses" ? COLORS.expenses : COLORS.investments;
+            const label = chartConfig[key]?.label;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => toggleMetric(key)}
+                className={`flex items-center gap-1.5 transition-opacity ${active ? "opacity-100" : "opacity-40 line-through"}`}
+              >
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: color }}
+                />
+                <span>{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/charts/expenses-category-chart.tsx
+++ b/app/components/charts/expenses-category-chart.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import type React from "react";
+import { Cell, Label, Pie, PieChart } from "recharts";
+import type { CategoryBreakdown } from "@/lib/queries/accounting";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// Distinct palette for up to 12 slices + an "Other" gray
+const SLICE_COLORS = [
+  "#2662d9",
+  "#2eb88a",
+  "#e23670",
+  "#eab308",
+  "#8b5cf6",
+  "#f97316",
+  "#06b6d4",
+  "#ec4899",
+  "#84cc16",
+  "#6366f1",
+  "#14b8a6",
+  "#f43f5e",
+];
+const OTHER_COLOR = "#6b7280";
+
+const formatCurrencyFull = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+interface ExpensesCategoryChartProps {
+  data: CategoryBreakdown[];
+  description?: React.ReactNode;
+}
+
+export function ExpensesCategoryChart({ data, description }: ExpensesCategoryChartProps) {
+  const grandTotal = data.reduce((sum, d) => sum + d.total, 0);
+
+  // Top 10 categories + "Other" bucket
+  const top = data.slice(0, 10);
+  const otherTotal = data.slice(10).reduce((sum, d) => sum + d.total, 0);
+  const chartData =
+    otherTotal > 0
+      ? [...top, { category: "Other", total: otherTotal }]
+      : top;
+
+  // Build chart config for legend / tooltip labels
+  const chartConfig: ChartConfig = Object.fromEntries(
+    chartData.map((d, i) => [
+      d.category,
+      {
+        label: d.category,
+        color: d.category === "Other" ? OTHER_COLOR : (SLICE_COLORS[i % SLICE_COLORS.length]),
+      },
+    ])
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          Total Expenses by Category
+        </CardTitle>
+        {description && <div className="mt-1">{description}</div>}
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-3">
+        <ChartContainer
+          config={chartConfig}
+          className="aspect-[4/3] w-full"
+        >
+          <PieChart>
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={(value, name) => (
+                    <div className="flex flex-1 justify-between gap-4">
+                      <span className="font-bold">{name}:</span>
+                      <span className="tabular-nums">
+                        {formatCurrencyFull(value as number)}
+                      </span>
+                    </div>
+                  )}
+                />
+              }
+            />
+            <Pie
+              data={chartData}
+              dataKey="total"
+              nameKey="category"
+              innerRadius="48%"
+              outerRadius="80%"
+              paddingAngle={1}
+            >
+              {chartData.map((entry, i) => (
+                <Cell
+                  key={entry.category}
+                  fill={
+                    entry.category === "Other"
+                      ? OTHER_COLOR
+                      : SLICE_COLORS[i % SLICE_COLORS.length]
+                  }
+                />
+              ))}
+              <Label
+                content={({ viewBox }) => {
+                  if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                    return (
+                      <text
+                        x={viewBox.cx}
+                        y={viewBox.cy}
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                      >
+                        <tspan
+                          x={viewBox.cx}
+                          y={(viewBox.cy ?? 0) - 12}
+                          className="fill-foreground text-3xl font-bold"
+                        >
+                          {formatCurrencyFull(grandTotal)}
+                        </tspan>
+                        <tspan
+                          x={viewBox.cx}
+                          y={(viewBox.cy ?? 0) + 14}
+                          className="fill-muted-foreground text-sm"
+                        >
+                          Total
+                        </tspan>
+                      </text>
+                    );
+                  }
+                  return null;
+                }}
+              />
+            </Pie>
+          </PieChart>
+        </ChartContainer>
+
+        {/* Legend */}
+        <div className="grid w-full grid-cols-2 gap-x-4 gap-y-1 text-xs">
+          {chartData.map((entry, i) => {
+            const pct =
+              grandTotal > 0
+                ? ((entry.total / grandTotal) * 100).toFixed(2)
+                : "0.00";
+            return (
+              <div key={entry.category} className="flex items-center gap-2">
+                <div
+                  className="h-2.5 w-2.5 shrink-0 rounded-sm"
+                  style={{
+                    backgroundColor:
+                      entry.category === "Other"
+                        ? OTHER_COLOR
+                        : SLICE_COLORS[i % SLICE_COLORS.length],
+                  }}
+                />
+                <span className="text-muted-foreground truncate">
+                  {entry.category}
+                </span>
+                <span className="ml-auto tabular-nums font-medium">
+                  {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/dashboard/accounting-filters.tsx
+++ b/app/components/dashboard/accounting-filters.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { DateRangePicker } from "@/components/ui/date-range-picker";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import {
+  Combobox,
+  ComboboxChips,
+  ComboboxChip,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxList,
+  ComboboxCollection,
+  ComboboxEmpty,
+  ComboboxItem,
+  useComboboxAnchor,
+} from "@/components/ui/combobox";
+
+const TIME_GROUPING_OPTIONS = [
+  { value: "day", label: "Day" },
+  { value: "week", label: "Week" },
+  { value: "month", label: "Month" },
+  { value: "quarter", label: "Quarter" },
+  { value: "year", label: "Year" },
+  { value: "day_of_week", label: "Day of Week" },
+  { value: "day_of_month", label: "Day of Month" },
+  { value: "day_of_year", label: "Day of Year" },
+  { value: "week_of_year", label: "Week of Year" },
+  { value: "month_of_year", label: "Month of Year" },
+  { value: "quarter_of_year", label: "Quarter of Year" },
+] as const;
+
+const TIME_GROUPING_LABELS: Record<string, string> = Object.fromEntries(
+  TIME_GROUPING_OPTIONS.map(({ value, label }) => [value, label])
+);
+
+interface LookupOption {
+  id: number;
+  name: string;
+}
+
+interface AccountingFiltersProps {
+  descriptions: string[];
+  accounts: LookupOption[];
+  categories: LookupOption[];
+  filters: {
+    dateFrom?: string;
+    dateTo?: string;
+    descriptions?: string[];
+    accountIds?: number[];
+    categoryIds?: number[];
+    timeGrouping?: string;
+  };
+}
+
+function FilterSlot({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      <Label className="text-xs">{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function MultiSelectFilter({
+  label,
+  param,
+  options,
+  selectedIds,
+  onUpdate,
+}: {
+  label: string;
+  param: string;
+  options: LookupOption[];
+  selectedIds: number[];
+  onUpdate: (param: string, values: number[]) => void;
+}) {
+  const anchor = useComboboxAnchor();
+
+  return (
+    <Combobox
+      value={selectedIds}
+      onValueChange={(val) => onUpdate(param, val as number[])}
+      items={options.map((o) => o.id)}
+      itemToStringLabel={(id: number) =>
+        options.find((o) => o.id === id)?.name ?? String(id)
+      }
+      multiple
+    >
+      <ComboboxChips ref={anchor} className="h-8 overflow-hidden flex-nowrap text-xs">
+        {selectedIds.slice(0, 2).map((chipId) => (
+          <ComboboxChip key={chipId} className="text-xs shrink-0">
+            {options.find((o) => o.id === chipId)?.name}
+          </ComboboxChip>
+        ))}
+        {selectedIds.length > 2 && (
+          <span
+            className="shrink-0 cursor-default rounded-sm bg-muted px-1.5 text-xs font-medium text-muted-foreground"
+            title={selectedIds
+              .slice(2)
+              .map((id) => options.find((o) => o.id === id)?.name)
+              .join(", ")}
+          >
+            +{selectedIds.length - 2}
+          </span>
+        )}
+        <ComboboxChipsInput
+          placeholder={
+            selectedIds.length === 0 ? `All ${label.toLowerCase()}s...` : ""
+          }
+          className="text-xs"
+        />
+      </ComboboxChips>
+      <ComboboxContent anchor={anchor}>
+        <ComboboxList>
+          <ComboboxCollection>
+            {(itemId: number) => (
+              <ComboboxItem key={itemId} value={itemId}>
+                {options.find((o) => o.id === itemId)?.name}
+              </ComboboxItem>
+            )}
+          </ComboboxCollection>
+          <ComboboxEmpty>No results found</ComboboxEmpty>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+function DescriptionFilter({
+  descriptions,
+  selectedDescriptions,
+  onUpdate,
+}: {
+  descriptions: string[];
+  selectedDescriptions: string[];
+  onUpdate: (param: string, values: string[]) => void;
+}) {
+  const anchor = useComboboxAnchor();
+
+  return (
+    <Combobox
+      value={selectedDescriptions}
+      onValueChange={(val) => onUpdate("descriptions", val as string[])}
+      items={descriptions}
+      itemToStringLabel={(item: string) => item}
+      multiple
+    >
+      <ComboboxChips ref={anchor} className="h-8 overflow-hidden flex-nowrap text-xs">
+        {selectedDescriptions.slice(0, 2).map((chipValue) => (
+          <ComboboxChip key={chipValue} className="text-xs shrink-0">
+            {chipValue}
+          </ComboboxChip>
+        ))}
+        {selectedDescriptions.length > 2 && (
+          <span
+            className="shrink-0 cursor-default rounded-sm bg-muted px-1.5 text-xs font-medium text-muted-foreground"
+            title={selectedDescriptions.slice(2).join(", ")}
+          >
+            +{selectedDescriptions.length - 2}
+          </span>
+        )}
+        <ComboboxChipsInput
+          placeholder={
+            selectedDescriptions.length === 0 ? "All descriptions..." : ""
+          }
+          className="text-xs"
+        />
+      </ComboboxChips>
+      <ComboboxContent anchor={anchor}>
+        <ComboboxList>
+          <ComboboxCollection>
+            {(item: string) => (
+              <ComboboxItem key={item} value={item}>
+                {item}
+              </ComboboxItem>
+            )}
+          </ComboboxCollection>
+          <ComboboxEmpty>No results found</ComboboxEmpty>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+export function AccountingFilters({
+  descriptions,
+  accounts,
+  categories,
+  filters,
+}: AccountingFiltersProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const defaultFrom = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 30);
+    return d.toISOString().slice(0, 10);
+  }, []);
+
+  const updateParams = useCallback(
+    (updates: Record<string, string | undefined>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value) {
+          params.set(key, value);
+        } else {
+          params.delete(key);
+        }
+      }
+      const qs = params.toString();
+      router.push(`/dashboard/accounting${qs ? `?${qs}` : ""}`);
+    },
+    [router, searchParams]
+  );
+
+  const handleDateRange = (
+    from: string | undefined,
+    to: string | undefined
+  ) => {
+    updateParams({ dateFrom: from, dateTo: to });
+  };
+
+  const handleMultiSelectIds = (param: string, values: number[]) => {
+    updateParams({
+      [param]: values.length > 0 ? values.join(",") : undefined,
+    });
+  };
+
+  const handleDescriptions = (_param: string, values: string[]) => {
+    updateParams({
+      descriptions: values.length > 0 ? values.join(",") : undefined,
+    });
+  };
+
+  const handleTimeGrouping = (value: string | null) => {
+    const v = value ?? "month";
+    updateParams({
+      timeGrouping: v === "month" ? undefined : v, // month is default
+    });
+  };
+
+  const hasAnyFilter =
+    filters.dateFrom ||
+    filters.dateTo ||
+    (filters.descriptions && filters.descriptions.length > 0) ||
+    (filters.accountIds && filters.accountIds.length > 0) ||
+    (filters.categoryIds && filters.categoryIds.length > 0) ||
+    (filters.timeGrouping && filters.timeGrouping !== "month");
+
+  const clearAll = () => {
+    router.push("/dashboard/accounting");
+  };
+
+  return (
+    <div className="flex flex-wrap items-end gap-2">
+      <FilterSlot label="Date" className="w-56">
+        <DateRangePicker
+          dateFrom={filters.dateFrom ?? defaultFrom}
+          dateTo={filters.dateTo ?? undefined}
+          onChange={handleDateRange}
+          className="h-8 text-xs"
+        />
+      </FilterSlot>
+
+      <FilterSlot label="Description" className="min-w-40 flex-1">
+        <DescriptionFilter
+          descriptions={descriptions}
+          selectedDescriptions={filters.descriptions ?? []}
+          onUpdate={handleDescriptions}
+        />
+      </FilterSlot>
+
+      <FilterSlot label="Account" className="min-w-36 flex-1">
+        <MultiSelectFilter
+          label="Account"
+          param="accountIds"
+          options={accounts}
+          selectedIds={filters.accountIds ?? []}
+          onUpdate={handleMultiSelectIds}
+        />
+      </FilterSlot>
+
+      <FilterSlot label="Transaction Category" className="min-w-36 flex-1">
+        <MultiSelectFilter
+          label="Category"
+          param="categoryIds"
+          options={categories}
+          selectedIds={filters.categoryIds ?? []}
+          onUpdate={handleMultiSelectIds}
+        />
+      </FilterSlot>
+
+      <FilterSlot label="Time grouping" className="w-36">
+        <Select
+          value={filters.timeGrouping ?? "month"}
+          onValueChange={handleTimeGrouping}
+        >
+          <SelectTrigger className="h-8 text-xs">
+            <span>{TIME_GROUPING_LABELS[filters.timeGrouping ?? "month"]}</span>
+          </SelectTrigger>
+          <SelectContent>
+            {TIME_GROUPING_OPTIONS.map(({ value, label }) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </FilterSlot>
+
+      {hasAnyFilter && (
+        <Button variant="ghost" size="xs" onClick={clearAll} className="mb-0.5">
+          Clear All
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/app/components/dashboard/accounting-kpi-card.tsx
+++ b/app/components/dashboard/accounting-kpi-card.tsx
@@ -1,0 +1,67 @@
+import { cn } from "@/lib/utils";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface ChangeInfo {
+  percent: number;
+  direction: "up" | "down" | "none";
+  label: string; // e.g. "vs. Feb: $24,368.99"
+}
+
+interface AccountingKpiCardProps {
+  title: string;
+  value: string;
+  subtitle?: string;
+  change?: ChangeInfo;
+  /** Which direction is "good" — "up" for income/investments, "down" for expenses */
+  positiveDirection?: "up" | "down";
+  className?: string;
+}
+
+export function AccountingKpiCard({
+  title,
+  value,
+  subtitle,
+  change,
+  positiveDirection = "down",
+  className,
+}: AccountingKpiCardProps) {
+  return (
+    <Card className={cn("flex-1", className)}>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-3xl font-bold tabular-nums tracking-tight">
+          {value}
+        </p>
+        {(subtitle || change) && (
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+            {subtitle && <span>{subtitle}</span>}
+            {change && change.direction !== "none" && (
+              <span
+                className={cn(
+                  "font-medium",
+                  change.direction === positiveDirection
+                    ? "text-green-500"
+                    : "text-red-500"
+                )}
+              >
+                {change.direction === "down" ? "\u2193" : "\u2191"}{" "}
+                {Math.abs(change.percent).toFixed(2)}%
+              </span>
+            )}
+            {change && change.direction === "none" && (
+              <span className="font-medium">No change</span>
+            )}
+            {change && <span>{change.label}</span>}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/lib/queries/accounting.ts
+++ b/app/lib/queries/accounting.ts
@@ -1,0 +1,438 @@
+import { db } from "@/lib/db";
+import { sql, type SQL } from "drizzle-orm";
+
+// ── Types ──
+
+export type TimeGrouping =
+  | "day"
+  | "week"
+  | "month"
+  | "quarter"
+  | "year"
+  | "day_of_week"
+  | "day_of_month"
+  | "day_of_year"
+  | "week_of_year"
+  | "month_of_year"
+  | "quarter_of_year";
+
+export interface AccountingTimeSeriesPoint {
+  date: string;
+  totalIncome: number;
+  totalExpenses: number;
+  totalInvestments: number;
+}
+
+export interface AccountingPeriodTotals {
+  totalIncome: number;
+  totalExpenses: number;
+  totalInvestments: number;
+}
+
+export interface AccountingToDateComparison {
+  currentIncome: number;
+  previousIncome: number;
+  currentExpenses: number;
+  previousExpenses: number;
+  currentInvestments: number;
+  previousInvestments: number;
+  currentMonthLabel: string;
+  previousMonthLabel: string;
+}
+
+export interface CategoryBreakdown {
+  category: string;
+  total: number;
+}
+
+export interface AccountingFilters {
+  dateFrom?: string;
+  dateTo?: string;
+  descriptions?: string[];
+  accountIds?: number[];
+  categoryIds?: number[];
+  timeGrouping?: TimeGrouping;
+}
+
+// ── Helpers ──
+
+// Transaction type IDs (from seed data)
+const INCOME_TYPE_ID = 4;
+const EXPENSE_TYPE_ID = 2;
+const INVESTMENT_TYPE_ID = 10;
+const ACCOUNTING_TYPE_IDS = [INCOME_TYPE_ID, EXPENSE_TYPE_ID, INVESTMENT_TYPE_ID];
+
+function buildFilterConditions(filters: AccountingFilters, tableAlias = "t"): SQL[] {
+  const conditions: SQL[] = [];
+
+  if (filters.dateFrom) {
+    conditions.push(sql.raw(`${tableAlias}.transaction_date >= '${filters.dateFrom}'`));
+  }
+  if (filters.dateTo) {
+    conditions.push(sql.raw(`${tableAlias}.transaction_date <= '${filters.dateTo}'`));
+  }
+  if (filters.descriptions && filters.descriptions.length > 0) {
+    const escaped = filters.descriptions.map((d) => d.replace(/'/g, "''"));
+    const list = escaped.map((d) => `'${d}'`).join(", ");
+    conditions.push(sql.raw(`${tableAlias}.transaction_description IN (${list})`));
+  }
+  if (filters.accountIds && filters.accountIds.length > 0) {
+    conditions.push(sql.raw(`${tableAlias}.account_id IN (${filters.accountIds.join(", ")})`));
+  }
+  if (filters.categoryIds && filters.categoryIds.length > 0) {
+    conditions.push(sql.raw(`${tableAlias}.transaction_category_id IN (${filters.categoryIds.join(", ")})`));
+  }
+
+  return conditions;
+}
+
+function whereFromConditions(conditions: SQL[]): SQL {
+  if (conditions.length === 0) return sql``;
+  return sql`WHERE ${sql.join(conditions, sql` AND `)}`;
+}
+
+// Map TimeGrouping to a SQL expression for the GROUP BY key.
+// date_trunc-based groupings return a date; extract-based return a number.
+const GROUPING_SQL: Record<TimeGrouping, string> = {
+  day: "date_trunc('day', t.transaction_date)::date",
+  week: "date_trunc('week', t.transaction_date)::date",
+  month: "date_trunc('month', t.transaction_date)::date",
+  quarter: "date_trunc('quarter', t.transaction_date)::date",
+  year: "date_trunc('year', t.transaction_date)::date",
+  day_of_week: "EXTRACT(dow FROM t.transaction_date)::int",
+  day_of_month: "EXTRACT(day FROM t.transaction_date)::int",
+  day_of_year: "EXTRACT(doy FROM t.transaction_date)::int",
+  week_of_year: "EXTRACT(week FROM t.transaction_date)::int",
+  month_of_year: "EXTRACT(month FROM t.transaction_date)::int",
+  quarter_of_year: "EXTRACT(quarter FROM t.transaction_date)::int",
+};
+
+// ── Query A: Time Series ──
+
+// Interval strings for generate_series stepping
+const GROUPING_INTERVALS: Partial<Record<TimeGrouping, string>> = {
+  day: "1 day",
+  week: "1 week",
+  month: "1 month",
+  quarter: "3 months",
+  year: "1 year",
+};
+
+// Extract-based groupings: generate_series(start, end) integer ranges
+const EXTRACT_RANGES: Partial<Record<TimeGrouping, { start: number; end: number }>> = {
+  day_of_week: { start: 0, end: 6 },
+  day_of_month: { start: 1, end: 31 },
+  day_of_year: { start: 1, end: 366 },
+  week_of_year: { start: 1, end: 53 },
+  month_of_year: { start: 1, end: 12 },
+  quarter_of_year: { start: 1, end: 4 },
+};
+
+export async function getAccountingTimeSeries(
+  filters: AccountingFilters
+): Promise<AccountingTimeSeriesPoint[]> {
+  const grouping = filters.timeGrouping ?? "month";
+  const groupExpr = GROUPING_SQL[grouping];
+  const conditions = buildFilterConditions(filters);
+  conditions.push(sql.raw(`t.transaction_type_id IN (${ACCOUNTING_TYPE_IDS.join(", ")})`));
+  const where = whereFromConditions(conditions);
+
+  const interval = GROUPING_INTERVALS[grouping];
+  const extractRange = EXTRACT_RANGES[grouping];
+
+  if (interval) {
+    // Date-trunc groupings: generate continuous date series
+    const dateFrom = filters.dateFrom ?? new Date().toISOString().slice(0, 10);
+    const dateTo = filters.dateTo ?? new Date().toISOString().slice(0, 10);
+    const truncUnit = TO_DATE_TRUNCATIONS[grouping] ?? "month";
+
+    const result = await db.execute(sql`
+      WITH series AS (
+        SELECT ${sql.raw(`date_trunc('${truncUnit}', d)::date`)} AS date
+        FROM generate_series(
+          ${sql.raw(`date_trunc('${truncUnit}', '${dateFrom}'::date)`)}::date,
+          ${dateTo}::date,
+          ${sql.raw(`'${interval}'::interval`)}
+        ) AS d
+      ),
+      agg AS (
+        SELECT
+          ${sql.raw(groupExpr)} AS date,
+          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_income,
+          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
+          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+        FROM transactions t
+        ${where}
+        GROUP BY 1
+      )
+      SELECT
+        s.date,
+        COALESCE(a.total_income, 0) AS total_income,
+        COALESCE(a.total_expenses, 0) AS total_expenses,
+        COALESCE(a.total_investments, 0) AS total_investments
+      FROM series s
+      LEFT JOIN agg a ON a.date = s.date
+      ORDER BY s.date ASC
+    `);
+
+    return (result.rows as { date: string; total_income: string; total_expenses: string; total_investments: string }[]).map(
+      (row) => ({
+        date: row.date,
+        totalIncome: parseFloat(row.total_income) || 0,
+        totalExpenses: parseFloat(row.total_expenses) || 0,
+        totalInvestments: parseFloat(row.total_investments) || 0,
+      })
+    );
+  }
+
+  if (extractRange) {
+    // Extract-based groupings: generate full integer range
+    const result = await db.execute(sql`
+      WITH series AS (
+        SELECT g AS date FROM generate_series(${sql.raw(String(extractRange.start))}, ${sql.raw(String(extractRange.end))}) AS g
+      ),
+      agg AS (
+        SELECT
+          ${sql.raw(groupExpr)} AS date,
+          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_income,
+          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
+          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+        FROM transactions t
+        ${where}
+        GROUP BY 1
+      )
+      SELECT
+        s.date,
+        COALESCE(a.total_income, 0) AS total_income,
+        COALESCE(a.total_expenses, 0) AS total_expenses,
+        COALESCE(a.total_investments, 0) AS total_investments
+      FROM series s
+      LEFT JOIN agg a ON a.date = s.date
+      ORDER BY s.date ASC
+    `);
+
+    return (result.rows as { date: string; total_income: string; total_expenses: string; total_investments: string }[]).map(
+      (row) => ({
+        date: row.date,
+        totalIncome: parseFloat(row.total_income) || 0,
+        totalExpenses: parseFloat(row.total_expenses) || 0,
+        totalInvestments: parseFloat(row.total_investments) || 0,
+      })
+    );
+  }
+
+  // Fallback (shouldn't happen)
+  return [];
+}
+
+// ── Query B: Period Totals ──
+
+export async function getAccountingPeriodTotals(
+  filters: AccountingFilters
+): Promise<AccountingPeriodTotals> {
+  const conditions = buildFilterConditions(filters);
+  conditions.push(sql.raw(`t.transaction_type_id IN (${ACCOUNTING_TYPE_IDS.join(", ")})`));
+  const where = whereFromConditions(conditions);
+
+  const result = await db.execute(sql`
+    SELECT
+      SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_income,
+      SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
+      SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+    FROM transactions t
+    ${where}
+  `);
+
+  const row = (result.rows as { total_income: string; total_expenses: string; total_investments: string }[])[0];
+  return {
+    totalIncome: parseFloat(row?.total_income) || 0,
+    totalExpenses: parseFloat(row?.total_expenses) || 0,
+    totalInvestments: parseFloat(row?.total_investments) || 0,
+  };
+}
+
+// ── Query C: To-Date Comparison (current vs previous period) ──
+
+// Standard groupings that support to-date comparison.
+// Extract-based groupings (day_of_week, month_of_year, etc.) do not.
+const TO_DATE_TRUNCATIONS: Partial<Record<TimeGrouping, string>> = {
+  day: "day",
+  week: "week",
+  month: "month",
+  quarter: "quarter",
+  year: "year",
+};
+
+const TO_DATE_INTERVALS: Record<string, string> = {
+  day: "1 day",
+  week: "1 week",
+  month: "1 month",
+  quarter: "3 months",
+  year: "1 year",
+};
+
+const TO_DATE_LABEL_FORMATS: Record<string, string> = {
+  day: "'DD Mon YYYY'",
+  month: "'Mon YYYY'",
+  quarter: "'\"Q\"Q YYYY'",
+  year: "'YYYY'",
+};
+
+// Week needs a date range label, so we build the full SQL expression
+function getLabelExpr(truncation: string, alias: string): string {
+  if (truncation === "week") {
+    return `to_char(${alias}, 'FMMM.FMDD.YYYY') || ' - ' || to_char(${alias} + interval '6 days', 'FMMM.FMDD.YYYY')`;
+  }
+  const fmt = TO_DATE_LABEL_FORMATS[truncation] ?? "'Mon YYYY'";
+  return `to_char(${alias}, ${fmt})`;
+}
+
+export function isStandardGrouping(grouping: TimeGrouping): boolean {
+  return grouping in TO_DATE_TRUNCATIONS;
+}
+
+export async function getAccountingToDateComparison(
+  filters: AccountingFilters
+): Promise<AccountingToDateComparison> {
+  const grouping = filters.timeGrouping ?? "month";
+  const truncation = TO_DATE_TRUNCATIONS[grouping] ?? "month";
+  const intervalStr = TO_DATE_INTERVALS[truncation] ?? "1 month";
+  const curLabelExpr = getLabelExpr(truncation, "p.cur_start");
+  const prevLabelExpr = getLabelExpr(truncation, "p.prev_start");
+
+  // Use dateTo as reference date (or today)
+  const refDate = filters.dateTo ?? new Date().toISOString().slice(0, 10);
+
+  // Build optional filter conditions (excluding date range — we handle that ourselves)
+  const extraConditions: SQL[] = [];
+  if (filters.descriptions && filters.descriptions.length > 0) {
+    const escaped = filters.descriptions.map((d) => d.replace(/'/g, "''"));
+    const list = escaped.map((d) => `'${d}'`).join(", ");
+    extraConditions.push(sql.raw(`t.transaction_description IN (${list})`));
+  }
+  if (filters.accountIds && filters.accountIds.length > 0) {
+    extraConditions.push(sql.raw(`t.account_id IN (${filters.accountIds.join(", ")})`));
+  }
+  if (filters.categoryIds && filters.categoryIds.length > 0) {
+    extraConditions.push(sql.raw(`t.transaction_category_id IN (${filters.categoryIds.join(", ")})`));
+  }
+  extraConditions.push(sql.raw(`t.transaction_type_id IN (${ACCOUNTING_TYPE_IDS.join(", ")})`));
+
+  const extraWhere = extraConditions.length > 0
+    ? sql`AND ${sql.join(extraConditions, sql` AND `)}`
+    : sql``;
+
+  const result = await db.execute(sql`
+    WITH params AS (
+      SELECT
+        date_trunc(${sql.raw(`'${truncation}'`)}, ${refDate}::date)::date AS cur_start,
+        ${refDate}::date AS cur_end,
+        (date_trunc(${sql.raw(`'${truncation}'`)}, ${refDate}::date) - interval ${sql.raw(`'${intervalStr}'`)})::date AS prev_start,
+        (date_trunc(${sql.raw(`'${truncation}'`)}, ${refDate}::date) - interval '1 day')::date AS prev_end
+    )
+    SELECT
+      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS cur_income,
+      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS prev_income,
+      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS cur_expenses,
+      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS prev_expenses,
+      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS cur_investments,
+      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS prev_investments,
+      MIN(${sql.raw(curLabelExpr)}) AS cur_label,
+      MIN(${sql.raw(prevLabelExpr)}) AS prev_label
+    FROM transactions t
+    CROSS JOIN params p
+    WHERE t.transaction_date >= p.prev_start
+      AND t.transaction_date <= p.cur_end
+      ${extraWhere}
+  `);
+
+  const row = (result.rows as Record<string, string>[])[0] ?? {};
+  return {
+    currentIncome: parseFloat(row.cur_income) || 0,
+    previousIncome: parseFloat(row.prev_income) || 0,
+    currentExpenses: parseFloat(row.cur_expenses) || 0,
+    previousExpenses: parseFloat(row.prev_expenses) || 0,
+    currentInvestments: parseFloat(row.cur_investments) || 0,
+    previousInvestments: parseFloat(row.prev_investments) || 0,
+    currentMonthLabel: row.cur_label ?? "",
+    previousMonthLabel: row.prev_label ?? "",
+  };
+}
+
+// ── Query D: Expense Category Breakdown ──
+
+export async function getExpenseCategoryBreakdown(
+  filters: AccountingFilters
+): Promise<CategoryBreakdown[]> {
+  const conditions = buildFilterConditions(filters);
+  conditions.push(sql.raw(`t.transaction_type_id = ${EXPENSE_TYPE_ID}`));
+  const where = whereFromConditions(conditions);
+
+  const result = await db.execute(sql`
+    SELECT
+      tc.transaction_category AS category,
+      SUM(ABS(t.amount)) AS total
+    FROM transactions t
+    JOIN transaction_categories tc USING (transaction_category_id)
+    ${where}
+    GROUP BY tc.transaction_category
+    ORDER BY total DESC
+  `);
+
+  return (result.rows as { category: string; total: string }[]).map((row) => ({
+    category: row.category,
+    total: parseFloat(row.total) || 0,
+  }));
+}
+
+// ── Query E: Average per Month (Last 12 complete months) ──
+
+export async function getAccountingMonthlyAverages(
+  filters: AccountingFilters
+): Promise<AccountingPeriodTotals> {
+  // Extra filters (non-date)
+  const extraConditions: SQL[] = [];
+  if (filters.descriptions && filters.descriptions.length > 0) {
+    const escaped = filters.descriptions.map((d) => d.replace(/'/g, "''"));
+    const list = escaped.map((d) => `'${d}'`).join(", ");
+    extraConditions.push(sql.raw(`t.transaction_description IN (${list})`));
+  }
+  if (filters.accountIds && filters.accountIds.length > 0) {
+    extraConditions.push(sql.raw(`t.account_id IN (${filters.accountIds.join(", ")})`));
+  }
+  if (filters.categoryIds && filters.categoryIds.length > 0) {
+    extraConditions.push(sql.raw(`t.transaction_category_id IN (${filters.categoryIds.join(", ")})`));
+  }
+  extraConditions.push(sql.raw(`t.transaction_type_id IN (${ACCOUNTING_TYPE_IDS.join(", ")})`));
+
+  const extraWhere = extraConditions.length > 0
+    ? sql`AND ${sql.join(extraConditions, sql` AND `)}`
+    : sql``;
+
+  const result = await db.execute(sql`
+    WITH monthly AS (
+      SELECT
+        date_trunc('month', t.transaction_date) AS month,
+        SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS income,
+        SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS expenses,
+        SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS investments
+      FROM transactions t
+      WHERE t.transaction_date >= date_trunc('month', CURRENT_DATE) - interval '12 months'
+        AND t.transaction_date < date_trunc('month', CURRENT_DATE)
+        ${extraWhere}
+      GROUP BY 1
+    )
+    SELECT
+      COALESCE(AVG(income), 0) AS avg_income,
+      COALESCE(AVG(expenses), 0) AS avg_expenses,
+      COALESCE(AVG(investments), 0) AS avg_investments
+    FROM monthly
+  `);
+
+  const row = (result.rows as { avg_income: string; avg_expenses: string; avg_investments: string }[])[0] ?? {};
+  return {
+    totalIncome: parseFloat(row.avg_income) || 0,
+    totalExpenses: parseFloat(row.avg_expenses) || 0,
+    totalInvestments: parseFloat(row.avg_investments) || 0,
+  };
+}


### PR DESCRIPTION
Here's the summary of the Personal Accounting page implementation:

**6 files** make up the feature:

1. **`page.tsx`** — Server component that parses URL filters, runs 7 parallel DB queries, computes change indicators, and renders the full layout (filters + charts + 9 KPI cards)

2. **`accounting.ts` (queries)** — 5 query functions using raw SQL for `generate_series`, `date_trunc`, and `EXTRACT` operations. Handles 11 time groupings, gap-filling for continuous charts, period comparisons, category breakdowns, and 12-month rolling averages. Reusable filter-building utilities construct WHERE clauses.

3. **`accounting-filters.tsx`** — Client component with combobox-based multi-selects for descriptions, accounts, and categories, plus date range and time grouping selectors. All state lives in URL params.

4. **`accounting-chart.tsx`** — Area chart (Chart.js) with toggleable legend, smart date formatting per grouping type, and compact currency axes.

5. **`expenses-category-chart.tsx`** — Donut chart showing top 10 categories + "Other" with a center total label.

6. **`accounting-kpi-card.tsx`** — Presentational card with color-coded change indicators (green/red based on whether up or down is "good").

**Key architectural choices**: URL-driven filter state, server-side parallel data fetching, raw SQL for complex date operations Drizzle can't express, and gap-filling via LEFT JOIN with generated series.

The full details are in the plan file.