### PR TITLE
Fix dashboard showing incorrect balances (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ finance-stack/
 │   │   └── integration/                  # Integration tests (requires Finances_Test DB)
 │   │       ├── setup.ts                  #   Global setup — asserts test DB URL
 │   │       ├── vitest-setup.ts           #   Per-test setup/teardown
-│   │       └── actions/                  #   Server action tests (account, transaction)
+│   │       ├── actions/                  #   Server action tests (account, transaction)
+│   │       └── queries/                  #   Query function tests (rebuild-balance)
 │   └── vitest.config.ts                  # Vitest configuration (unit + integration projects)
 ├── .github/workflows/ci.yml             # CI: lint + unit tests + integration tests on push/PR
 ├── init-db/
@@ -317,6 +318,13 @@ docker compose down
 Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
+
+### 2026-04-04 — v0.1.2
+
+**Fix dashboard showing incorrect balances (Issue #68)**
+- Added `ensureTodayBalances()` carry-forward function in `lib/queries/rebuild-balance.ts`: on each dashboard load, inserts a today row for every open account (carrying forward the most recent cumulative balance) if one doesn't already exist
+- Called from `app/(app)/dashboard/layout.tsx` as an async server component — runs on every dashboard page load but is a no-op after the first call of the day
+- Added integration tests for the new function covering carry-forward, idempotency, closed-account exclusion, and coexistence with `rebuildAccountBalance()`
 
 ### 2026-03-29 — v0.1.1
 

--- a/app/app/(app)/dashboard/layout.tsx
+++ b/app/app/(app)/dashboard/layout.tsx
@@ -1,10 +1,13 @@
 import { DashboardTabs } from "./dashboard-tabs";
+import { ensureTodayBalances } from "@/lib/queries/rebuild-balance";
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  await ensureTodayBalances();
+
   return (
     <div className="p-6">
       <DashboardTabs />

--- a/app/lib/queries/rebuild-balance.ts
+++ b/app/lib/queries/rebuild-balance.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { db } from "@/lib/db";
 
 /**
  * Rebuilds account_balance_history rows for a single account.
@@ -69,5 +70,35 @@ export async function rebuildAccountBalance(
     DO UPDATE
     SET daily_balance = EXCLUDED.daily_balance,
         cumulative_balance = EXCLUDED.cumulative_balance
+  `);
+}
+
+/**
+ * Ensures every open account has an account_balance_history row for today.
+ *
+ * If a row doesn't already exist, carries forward the most recent
+ * cumulative_balance with daily_balance = 0.  Idempotent via
+ * ON CONFLICT DO NOTHING — existing rows (e.g. from rebuildAccountBalance)
+ * are never overwritten.
+ */
+export async function ensureTodayBalances(): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO account_balance_history
+      (account_id, balance_date, daily_balance, cumulative_balance)
+    SELECT
+      a.account_id,
+      CURRENT_DATE,
+      0,
+      COALESCE(abh.cumulative_balance, 0)
+    FROM accounts a
+    LEFT JOIN account_balance_history abh
+      ON abh.account_id = a.account_id
+      AND abh.balance_date = (
+        SELECT MAX(balance_date)
+        FROM account_balance_history
+        WHERE account_id = a.account_id
+      )
+    WHERE a.closed_date IS NULL
+    ON CONFLICT (account_id, balance_date) DO NOTHING
   `);
 }

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start -p 3001",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/app/tests/integration/queries/rebuild-balance.test.ts
+++ b/app/tests/integration/queries/rebuild-balance.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { db } from "@/lib/db";
+import { accounts, accountBalanceHistory } from "@/drizzle/schema";
+import { eq, and } from "drizzle-orm";
+import { ensureTodayBalances } from "@/lib/queries/rebuild-balance";
+
+const today = new Date().toISOString().slice(0, 10);
+const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+
+// Track account IDs created during tests so we can clean them up
+const createdAccountIds: number[] = [];
+
+afterEach(async () => {
+  for (const id of createdAccountIds) {
+    await db.delete(accountBalanceHistory).where(eq(accountBalanceHistory.accountId, id));
+    await db.delete(accounts).where(eq(accounts.accountId, id));
+  }
+  createdAccountIds.length = 0;
+});
+
+describe("ensureTodayBalances", () => {
+  it("creates a carry-forward row for today when none exists", async () => {
+    // Create an open account with a historical balance row
+    const [account] = await db
+      .insert(accounts)
+      .values({ accountName: "Carry Forward Test", accountTypeId: 1 })
+      .returning({ accountId: accounts.accountId });
+    createdAccountIds.push(account.accountId);
+
+    await db.insert(accountBalanceHistory).values({
+      accountId: account.accountId,
+      balanceDate: yesterday,
+      dailyBalance: "100.00",
+      cumulativeBalance: "500.00",
+    });
+
+    await ensureTodayBalances();
+
+    const rows = await db
+      .select()
+      .from(accountBalanceHistory)
+      .where(
+        and(
+          eq(accountBalanceHistory.accountId, account.accountId),
+          eq(accountBalanceHistory.balanceDate, today)
+        )
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dailyBalance).toBe("0.00");
+    expect(rows[0].cumulativeBalance).toBe("500.00");
+  });
+
+  it("is idempotent — calling twice does not duplicate or overwrite rows", async () => {
+    const [account] = await db
+      .insert(accounts)
+      .values({ accountName: "Idempotent Test", accountTypeId: 1 })
+      .returning({ accountId: accounts.accountId });
+    createdAccountIds.push(account.accountId);
+
+    await db.insert(accountBalanceHistory).values({
+      accountId: account.accountId,
+      balanceDate: yesterday,
+      dailyBalance: "50.00",
+      cumulativeBalance: "200.00",
+    });
+
+    await ensureTodayBalances();
+    await ensureTodayBalances();
+
+    const rows = await db
+      .select()
+      .from(accountBalanceHistory)
+      .where(
+        and(
+          eq(accountBalanceHistory.accountId, account.accountId),
+          eq(accountBalanceHistory.balanceDate, today)
+        )
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cumulativeBalance).toBe("200.00");
+  });
+
+  it("does not overwrite an existing row for today", async () => {
+    const [account] = await db
+      .insert(accounts)
+      .values({ accountName: "Existing Row Test", accountTypeId: 1 })
+      .returning({ accountId: accounts.accountId });
+    createdAccountIds.push(account.accountId);
+
+    // Simulate a row created by rebuildAccountBalance (from a transaction today)
+    await db.insert(accountBalanceHistory).values({
+      accountId: account.accountId,
+      balanceDate: today,
+      dailyBalance: "75.00",
+      cumulativeBalance: "1000.00",
+    });
+
+    await ensureTodayBalances();
+
+    const rows = await db
+      .select()
+      .from(accountBalanceHistory)
+      .where(
+        and(
+          eq(accountBalanceHistory.accountId, account.accountId),
+          eq(accountBalanceHistory.balanceDate, today)
+        )
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dailyBalance).toBe("75.00");
+    expect(rows[0].cumulativeBalance).toBe("1000.00");
+  });
+
+  it("skips closed accounts", async () => {
+    const [account] = await db
+      .insert(accounts)
+      .values({
+        accountName: "Closed Account Test",
+        accountTypeId: 1,
+        closedDate: yesterday,
+      })
+      .returning({ accountId: accounts.accountId });
+    createdAccountIds.push(account.accountId);
+
+    await db.insert(accountBalanceHistory).values({
+      accountId: account.accountId,
+      balanceDate: yesterday,
+      dailyBalance: "10.00",
+      cumulativeBalance: "300.00",
+    });
+
+    await ensureTodayBalances();
+
+    const rows = await db
+      .select()
+      .from(accountBalanceHistory)
+      .where(
+        and(
+          eq(accountBalanceHistory.accountId, account.accountId),
+          eq(accountBalanceHistory.balanceDate, today)
+        )
+      );
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("defaults to 0 cumulative balance for accounts with no history", async () => {
+    const [account] = await db
+      .insert(accounts)
+      .values({ accountName: "No History Test", accountTypeId: 1 })
+      .returning({ accountId: accounts.accountId });
+    createdAccountIds.push(account.accountId);
+
+    await ensureTodayBalances();
+
+    const rows = await db
+      .select()
+      .from(accountBalanceHistory)
+      .where(
+        and(
+          eq(accountBalanceHistory.accountId, account.accountId),
+          eq(accountBalanceHistory.balanceDate, today)
+        )
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dailyBalance).toBe("0.00");
+    expect(rows[0].cumulativeBalance).toBe("0.00");
+  });
+});


### PR DESCRIPTION
## Summary

- **Added `ensureTodayBalances()` carry-forward function** in `lib/queries/rebuild-balance.ts` — on each dashboard load, inserts a today row for every open account (carrying forward the most recent cumulative balance with `daily_balance = 0`) if one doesn't already exist. Idempotent via `ON CONFLICT DO NOTHING`.
- **Called from dashboard layout** (`app/(app)/dashboard/layout.tsx`) as an async server component — runs on every dashboard page load but is a no-op after the first call of the day.
- **Added `typecheck` script** to `package.json` (`tsc --noEmit`).
- **Added integration tests** for the new function covering carry-forward creation, idempotency, no-overwrite of existing rows, closed-account exclusion, and zero-balance default for accounts with no history.
- **Updated README** with v0.1.2 changelog entry and new `tests/integration/queries/` directory in project structure.

## Test plan

- [x] New integration tests pass (5/5): `npm run test:integration`
- [x] Full test suite passes with no regressions (61/61)
- [x] Manual: load dashboard without submitting any transactions today — KPIs and line graphs should show correct values

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)