### PR TITLE
Issue #89, #90, #91, #92 - Enhancements to Net Worth drilldown page

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ finance-stack/
 │   │   │   ├── accounting-filters.tsx    # Multi-select combobox filters for accounting page
 │   │   │   ├── accounting-kpi-card.tsx   # KPI card with change indicator for accounting metrics
 │   │   │   ├── date-range-filter.tsx     # URL-param-driven date range filter wrapper
-│   │   │   ├── net-worth-drivers-table.tsx # Net worth drivers table by account type category
+│   │   │   ├── net-worth-drivers-table.tsx # Expandable net worth drivers table (category → account type → account)
 │   │   │   └── summary-drilldown-tabs.tsx # Sub-navigation tabs for Summary drill-down pages
 │   │   └── transactions/                 # Transaction-specific components
 │   │       ├── transaction-form.tsx      # Transaction entry form (client component)
@@ -331,6 +331,17 @@ docker compose down
 Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
+
+### 2026-04-14 — v0.1.1 (continued)
+
+**Net Worth drill-down: nested drivers and By Account Type decomposition**
+- Net Worth Drivers table is now a 3-level expandable hierarchy: account type category → account type → account. Rows expand in place with chevron toggles and preserve scroll position across expands/collapses
+- Replaced the single `% Impact` column with `% of Parent` and `% of Total` so users can see both the local contribution at each level and the share of total net worth change
+- `getNetWorthDrivers()` rewritten to aggregate directly from `account_balance_history` in a single query (previously derived from the waterfall result), returning the full nested `DriverCategory → DriverAccountType → DriverAccount` shape
+- `getNetWorthTrendDecomposition()` now returns `accountTypeId` and `accountTypeName` on each point so the chart can pivot at the account-type level
+- Time Series chart: added a "By Account Type" mode alongside Net Worth / By Category / By Account, and added Select All / Clear All shortcuts to the clickable legend
+- Drill-down page layout: Drivers table is now full-width; Time Series and Waterfall sit side-by-side at a fixed height. Waterfall tooltip no longer double-lists the value row
+- Integration tests updated to assert the nested drivers shape, that child changes sum to parent change at every level, that category `% of Total` sums to ~100, and that decomposition points expose the new account-type fields
 
 ### 2026-04-12 — v0.1.1 (continued)
 

--- a/app/app/(app)/dashboard/net-worth/page.tsx
+++ b/app/app/(app)/dashboard/net-worth/page.tsx
@@ -81,16 +81,20 @@ export default async function NetWorthDrilldownPage({
         </CardContent>
       </Card>
 
-      {/* ── Main grid: Chart (left, spans 2 rows) + Waterfall & Drivers (right) ── */}
-      <div className="grid gap-6 lg:grid-cols-2 lg:grid-rows-[auto_auto]">
-        <div className="lg:row-span-2">
+      {/* ── Net Worth Drivers (full width) ── */}
+      <NetWorthDriversTable data={drivers} />
+
+      {/* ── Time Series + Waterfall (equal split, fixed height) ── */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="h-[500px]">
           <NetWorthTimeSeriesChart
             timeSeries={timeSeries}
             decomposition={decomposition}
           />
         </div>
-        <WaterfallChart data={waterfall} />
-        <NetWorthDriversTable data={drivers} />
+        <div className="h-[500px]">
+          <WaterfallChart data={waterfall} />
+        </div>
       </div>
     </div>
   );

--- a/app/components/charts/net-worth-timeseries-chart.tsx
+++ b/app/components/charts/net-worth-timeseries-chart.tsx
@@ -47,7 +47,7 @@ const formatDate = (dateStr: string) => {
   return format(d, "MMM d");
 };
 
-type Mode = "net-worth" | "category" | "account";
+type Mode = "net-worth" | "category" | "account-type" | "account";
 
 interface SeriesInfo {
   key: string;
@@ -62,17 +62,23 @@ interface PivotedRow {
 
 function pivotDecomposition(
   points: DecompositionPoint[],
-  mode: "category" | "account"
+  mode: "category" | "account-type" | "account"
 ): { rows: PivotedRow[]; series: SeriesInfo[] } {
+  const keyFor = (p: DecompositionPoint) => {
+    if (mode === "category") return `cat_${p.categoryId}`;
+    if (mode === "account-type") return `type_${p.accountTypeId}`;
+    return `acct_${p.accountId}`;
+  };
+  const labelFor = (p: DecompositionPoint) => {
+    if (mode === "category") return p.categoryName;
+    if (mode === "account-type") return p.accountTypeName;
+    return p.accountName;
+  };
+
   const seriesMap = new Map<string, string>();
   for (const p of points) {
-    if (mode === "category") {
-      const key = `cat_${p.categoryId}`;
-      if (!seriesMap.has(key)) seriesMap.set(key, p.categoryName);
-    } else {
-      const key = `acct_${p.accountId}`;
-      if (!seriesMap.has(key)) seriesMap.set(key, p.accountName);
-    }
+    const key = keyFor(p);
+    if (!seriesMap.has(key)) seriesMap.set(key, labelFor(p));
   }
 
   const series: SeriesInfo[] = Array.from(seriesMap.entries()).map(
@@ -91,8 +97,7 @@ function pivotDecomposition(
       dateMap.set(p.date, row);
     }
     const row = dateMap.get(p.date)!;
-    const key =
-      mode === "category" ? `cat_${p.categoryId}` : `acct_${p.accountId}`;
+    const key = keyFor(p);
     row[key] = ((row[key] as number) || 0) + p.cumulativeBalance;
   }
 
@@ -165,6 +170,7 @@ export function NetWorthTimeSeriesChart({
             [
               { value: "net-worth", label: "Net Worth" },
               { value: "category", label: "By Category" },
+              { value: "account-type", label: "By Account Type" },
               { value: "account", label: "By Account" },
             ] as const
           ).map((opt) => (
@@ -262,6 +268,27 @@ export function NetWorthTimeSeriesChart({
         {/* Clickable legend for decomposition modes */}
         {mode !== "net-worth" && (
           <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-3 text-xs">
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => setHiddenSeries(new Set())}
+                className="hover:text-foreground hover:underline"
+              >
+                Select All
+              </button>
+              <span className="text-border">|</span>
+              <button
+                type="button"
+                onClick={() =>
+                  setHiddenSeries(
+                    new Set(decomposed.series.map((s) => s.key))
+                  )
+                }
+                className="hover:text-foreground hover:underline"
+              >
+                Clear All
+              </button>
+            </div>
             {decomposed.series.map((s) => {
               const active = !hiddenSeries.has(s.key);
               return (

--- a/app/components/charts/waterfall-chart.tsx
+++ b/app/components/charts/waterfall-chart.tsx
@@ -108,14 +108,14 @@ export function WaterfallChart({ data }: WaterfallChartProps) {
   const bars = buildWaterfallBars(data);
 
   return (
-    <Card>
+    <Card className="flex h-full flex-col">
       <CardHeader>
         <CardTitle className="text-sm font-medium">
           Net Worth Waterfall
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <ChartContainer config={chartConfig} className="aspect-[2/1] w-full">
+      <CardContent className="flex min-h-0 flex-1 flex-col">
+        <ChartContainer config={chartConfig} className="min-h-0 flex-1 w-full">
           <BarChart data={bars} margin={{ left: 8, right: 8 }}>
             <CartesianGrid vertical={false} />
             <XAxis
@@ -134,8 +134,11 @@ export function WaterfallChart({ data }: WaterfallChartProps) {
               width={60}
             />
             <ChartTooltip
-              content={
+              content={({ active, payload, label }) => (
                 <ChartTooltipContent
+                  active={active}
+                  label={label}
+                  payload={payload?.filter((p) => p.dataKey === "value")}
                   formatter={(_, __, item) => {
                     const bar = item?.payload as WaterfallBar | undefined;
                     if (!bar) return null;
@@ -154,7 +157,7 @@ export function WaterfallChart({ data }: WaterfallChartProps) {
                   }}
                   labelFormatter={(label) => String(label)}
                 />
-              }
+              )}
             />
             {/* Invisible base bar */}
             <Bar dataKey="base" stackId="waterfall" fill="transparent" />

--- a/app/components/dashboard/net-worth-drivers-table.tsx
+++ b/app/components/dashboard/net-worth-drivers-table.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
 import type { DriversData } from "@/lib/queries/net-worth-drilldown";
 import {
   Table,
@@ -43,6 +47,42 @@ interface NetWorthDriversTableProps {
 }
 
 export function NetWorthDriversTable({ data }: NetWorthDriversTableProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const rowRefs = useRef<Map<string, HTMLTableRowElement | null>>(new Map());
+  const pendingScroll = useRef<{ key: string; top: number } | null>(null);
+
+  const toggle = (key: string) => {
+    const row = rowRefs.current.get(key);
+    if (row) {
+      pendingScroll.current = {
+        key,
+        top: row.getBoundingClientRect().top,
+      };
+    }
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  useLayoutEffect(() => {
+    const pending = pendingScroll.current;
+    if (!pending) return;
+    const row = rowRefs.current.get(pending.key);
+    if (row) {
+      const delta = row.getBoundingClientRect().top - pending.top;
+      if (delta !== 0) window.scrollBy(0, delta);
+    }
+    pendingScroll.current = null;
+  }, [expanded]);
+
+  const setRowRef = (key: string) => (el: HTMLTableRowElement | null) => {
+    if (el) rowRefs.current.set(key, el);
+    else rowRefs.current.delete(key);
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -56,27 +96,109 @@ export function NetWorthDriversTable({ data }: NetWorthDriversTableProps) {
             <TableRow>
               <TableHead>Account Type Category</TableHead>
               <TableHead className="text-right">Change</TableHead>
-              <TableHead className="text-right">% Impact</TableHead>
+              <TableHead className="text-right">% of Parent</TableHead>
+              <TableHead className="text-right">% of Total</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {data.categories.map((row) => (
-              <TableRow key={row.categoryId}>
-                <TableCell className="text-muted-foreground">
-                  {row.categoryName}
-                </TableCell>
-                <TableCell
-                  className={`text-right tabular-nums ${valueColor(row.change)}`}
-                >
-                  {signedCurrency(row.change)}
-                </TableCell>
-                <TableCell
-                  className={`text-right tabular-nums ${valueColor(row.percentImpact)}`}
-                >
-                  {signedPercent(row.percentImpact)}
-                </TableCell>
-              </TableRow>
-            ))}
+            {data.categories.map((cat) => {
+              const catKey = `cat:${cat.categoryId}`;
+              const catOpen = expanded.has(catKey);
+              const Chevron = catOpen ? ChevronDown : ChevronRight;
+              return (
+                <Fragment key={catKey}>
+                  <TableRow
+                    ref={setRowRef(catKey)}
+                    className="cursor-pointer"
+                    onClick={() => toggle(catKey)}
+                  >
+                    <TableCell className="text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
+                        <Chevron className="h-4 w-4" />
+                        {cat.categoryName}
+                      </span>
+                    </TableCell>
+                    <TableCell
+                      className={`text-right tabular-nums ${valueColor(cat.change)}`}
+                    >
+                      {signedCurrency(cat.change)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      —
+                    </TableCell>
+                    <TableCell
+                      className={`text-right tabular-nums ${valueColor(cat.percentOfTotal)}`}
+                    >
+                      {signedPercent(cat.percentOfTotal)}
+                    </TableCell>
+                  </TableRow>
+                  {catOpen &&
+                    cat.accountTypes.map((type) => {
+                      const typeKey = `type:${cat.categoryId}:${type.accountTypeId}`;
+                      const typeOpen = expanded.has(typeKey);
+                      const TypeChevron = typeOpen
+                        ? ChevronDown
+                        : ChevronRight;
+                      return (
+                        <Fragment key={typeKey}>
+                          <TableRow
+                            ref={setRowRef(typeKey)}
+                            className="cursor-pointer"
+                            onClick={() => toggle(typeKey)}
+                          >
+                            <TableCell className="text-muted-foreground pl-8">
+                              <span className="inline-flex items-center gap-1">
+                                <TypeChevron className="h-4 w-4" />
+                                {type.accountTypeName}
+                              </span>
+                            </TableCell>
+                            <TableCell
+                              className={`text-right tabular-nums ${valueColor(type.change)}`}
+                            >
+                              {signedCurrency(type.change)}
+                            </TableCell>
+                            <TableCell
+                              className={`text-right tabular-nums ${valueColor(type.percentOfParent)}`}
+                            >
+                              {signedPercent(type.percentOfParent)}
+                            </TableCell>
+                            <TableCell
+                              className={`text-right tabular-nums ${valueColor(type.percentOfTotal)}`}
+                            >
+                              {signedPercent(type.percentOfTotal)}
+                            </TableCell>
+                          </TableRow>
+                          {typeOpen &&
+                            type.accounts.map((acc) => (
+                              <TableRow
+                                key={`acc:${cat.categoryId}:${type.accountTypeId}:${acc.accountId}`}
+                              >
+                                <TableCell className="text-muted-foreground pl-14">
+                                  {acc.accountName}
+                                </TableCell>
+                                <TableCell
+                                  className={`text-right tabular-nums ${valueColor(acc.change)}`}
+                                >
+                                  {signedCurrency(acc.change)}
+                                </TableCell>
+                                <TableCell
+                                  className={`text-right tabular-nums ${valueColor(acc.percentOfParent)}`}
+                                >
+                                  {signedPercent(acc.percentOfParent)}
+                                </TableCell>
+                                <TableCell
+                                  className={`text-right tabular-nums ${valueColor(acc.percentOfTotal)}`}
+                                >
+                                  {signedPercent(acc.percentOfTotal)}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                        </Fragment>
+                      );
+                    })}
+                </Fragment>
+              );
+            })}
           </TableBody>
           <TableFooter>
             <TableRow>
@@ -85,6 +207,9 @@ export function NetWorthDriversTable({ data }: NetWorthDriversTableProps) {
                 className={`text-right font-bold tabular-nums ${valueColor(data.totalChange)}`}
               >
                 {signedCurrency(data.totalChange)}
+              </TableCell>
+              <TableCell className="text-right font-bold tabular-nums text-muted-foreground">
+                —
               </TableCell>
               <TableCell className="text-right font-bold tabular-nums">
                 {data.totalChange !== 0 ? "100.00%" : "0.00%"}

--- a/app/lib/queries/net-worth-drilldown.ts
+++ b/app/lib/queries/net-worth-drilldown.ts
@@ -20,22 +20,42 @@ export interface WaterfallData {
   categories: WaterfallCategory[];
 }
 
-export interface DriverRow {
+export interface DriverAccount {
+  accountId: number;
+  accountName: string;
+  change: number;
+  percentOfParent: number;
+  percentOfTotal: number;
+}
+
+export interface DriverAccountType {
+  accountTypeId: number;
+  accountTypeName: string;
+  change: number;
+  percentOfParent: number;
+  percentOfTotal: number;
+  accounts: DriverAccount[];
+}
+
+export interface DriverCategory {
   categoryId: number;
   categoryName: string;
   change: number;
-  percentImpact: number;
+  percentOfTotal: number;
+  accountTypes: DriverAccountType[];
 }
 
 export interface DriversData {
   totalChange: number;
-  categories: DriverRow[];
+  categories: DriverCategory[];
 }
 
 export interface DecompositionPoint {
   date: string;
   categoryId: number;
   categoryName: string;
+  accountTypeId: number;
+  accountTypeName: string;
   accountId: number;
   accountName: string;
   cumulativeBalance: number;
@@ -109,18 +129,145 @@ export async function getNetWorthDrivers(
   dateFrom: string,
   dateTo?: string
 ): Promise<DriversData> {
-  const waterfall = await getNetWorthWaterfall(dateFrom, dateTo);
-  const totalChange = waterfall.endNetWorth - waterfall.startNetWorth;
+  const endDate = dateTo ?? sql`CURRENT_DATE`;
 
-  const categories: DriverRow[] = waterfall.categories.map((c) => ({
-    categoryId: c.categoryId,
-    categoryName: c.categoryName,
-    change: c.change,
-    percentImpact:
-      totalChange !== 0
-        ? Math.round((c.change / totalChange) * 10000) / 100
-        : 0,
-  }));
+  const result = await db.execute(sql`
+    SELECT
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      a.account_id,
+      a.account_name,
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    WHERE atc.account_type_category_id != ${NET_WORTH_EXCLUDED_CATEGORY_ID}
+      AND abh.balance_date IN (${dateFrom}::date, ${endDate}::date)
+    GROUP BY
+      atc.account_type_category_id, atc.account_type_category,
+      at.account_type_id, at.account_type,
+      a.account_id, a.account_name
+    ORDER BY atc.account_type_category_id, at.account_type_id, a.account_id
+  `);
+
+  type Row = {
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    account_id: number;
+    account_name: string;
+    start_balance: string;
+    end_balance: string;
+  };
+
+  const rows = result.rows as Row[];
+
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+  const pct = (num: number, den: number) =>
+    den !== 0 ? round2((num / den) * 100) : 0;
+
+  const catMap = new Map<
+    number,
+    {
+      categoryId: number;
+      categoryName: string;
+      change: number;
+      types: Map<
+        number,
+        {
+          accountTypeId: number;
+          accountTypeName: string;
+          change: number;
+          accounts: DriverAccount[];
+        }
+      >;
+    }
+  >();
+
+  for (const row of rows) {
+    const start = parseFloat(row.start_balance) || 0;
+    const end = parseFloat(row.end_balance) || 0;
+    const change = end - start;
+
+    let cat = catMap.get(row.category_id);
+    if (!cat) {
+      cat = {
+        categoryId: row.category_id,
+        categoryName: row.category_name,
+        change: 0,
+        types: new Map(),
+      };
+      catMap.set(row.category_id, cat);
+    }
+    cat.change += change;
+
+    let type = cat.types.get(row.account_type_id);
+    if (!type) {
+      type = {
+        accountTypeId: row.account_type_id,
+        accountTypeName: row.account_type_name,
+        change: 0,
+        accounts: [],
+      };
+      cat.types.set(row.account_type_id, type);
+    }
+    type.change += change;
+    type.accounts.push({
+      accountId: row.account_id,
+      accountName: row.account_name,
+      change,
+      percentOfParent: 0,
+      percentOfTotal: 0,
+    });
+  }
+
+  const totalChange = Array.from(catMap.values()).reduce(
+    (s, c) => s + c.change,
+    0
+  );
+
+  const categories: DriverCategory[] = Array.from(catMap.values()).map(
+    (cat) => {
+      const accountTypes: DriverAccountType[] = Array.from(
+        cat.types.values()
+      ).map((t) => {
+        const accounts = t.accounts
+          .map((a) => ({
+            ...a,
+            percentOfParent: pct(a.change, t.change),
+            percentOfTotal: pct(a.change, totalChange),
+          }))
+          .sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+
+        return {
+          accountTypeId: t.accountTypeId,
+          accountTypeName: t.accountTypeName,
+          change: t.change,
+          percentOfParent: pct(t.change, cat.change),
+          percentOfTotal: pct(t.change, totalChange),
+          accounts,
+        };
+      });
+
+      accountTypes.sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+
+      return {
+        categoryId: cat.categoryId,
+        categoryName: cat.categoryName,
+        change: cat.change,
+        percentOfTotal: pct(cat.change, totalChange),
+        accountTypes,
+      };
+    }
+  );
 
   return { totalChange, categories };
 }
@@ -151,6 +298,8 @@ export async function getNetWorthTrendDecomposition(
       abh.balance_date AS date,
       atc.account_type_category_id AS category_id,
       atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
       a.account_id,
       a.account_name,
       abh.cumulative_balance
@@ -167,6 +316,8 @@ export async function getNetWorthTrendDecomposition(
     date: string;
     category_id: number;
     category_name: string;
+    account_type_id: number;
+    account_type_name: string;
     account_id: number;
     account_name: string;
     cumulative_balance: string;
@@ -176,6 +327,8 @@ export async function getNetWorthTrendDecomposition(
     date: row.date,
     categoryId: row.category_id,
     categoryName: row.category_name,
+    accountTypeId: row.account_type_id,
+    accountTypeName: row.account_type_name,
     accountId: row.account_id,
     accountName: row.account_name,
     cumulativeBalance: parseFloat(row.cumulative_balance) || 0,

--- a/app/tests/integration/queries/net-worth-drilldown.test.ts
+++ b/app/tests/integration/queries/net-worth-drilldown.test.ts
@@ -71,7 +71,7 @@ describe("getNetWorthWaterfall", () => {
 });
 
 describe("getNetWorthDrivers", () => {
-  it("returns total change and per-category percent impacts", async () => {
+  it("returns total change and nested category/type/account rows", async () => {
     const result = await getNetWorthDrivers(thirtyDaysAgo, today);
 
     expect(result).toHaveProperty("totalChange");
@@ -79,38 +79,59 @@ describe("getNetWorthDrivers", () => {
     expect(result.categories.length).toBeGreaterThan(0);
 
     for (const cat of result.categories) {
+      expect(cat).toHaveProperty("categoryId");
       expect(cat).toHaveProperty("categoryName");
       expect(cat).toHaveProperty("change");
-      expect(cat).toHaveProperty("percentImpact");
+      expect(cat).toHaveProperty("percentOfTotal");
+      expect(cat.accountTypes).toBeInstanceOf(Array);
+      expect(cat.accountTypes.length).toBeGreaterThan(0);
+
+      for (const t of cat.accountTypes) {
+        expect(t).toHaveProperty("accountTypeId");
+        expect(t).toHaveProperty("accountTypeName");
+        expect(t).toHaveProperty("percentOfParent");
+        expect(t).toHaveProperty("percentOfTotal");
+        expect(t.accounts).toBeInstanceOf(Array);
+        expect(t.accounts.length).toBeGreaterThan(0);
+
+        for (const a of t.accounts) {
+          expect(a).toHaveProperty("accountId");
+          expect(a).toHaveProperty("accountName");
+          expect(a).toHaveProperty("change");
+          expect(a).toHaveProperty("percentOfParent");
+          expect(a).toHaveProperty("percentOfTotal");
+        }
+      }
     }
   });
 
-  it("percent impacts sum to approximately 100 when total change is nonzero", async () => {
+  it("category percent-of-total sums to approximately 100 when total change is nonzero", async () => {
     const result = await getNetWorthDrivers(thirtyDaysAgo, today);
 
     if (result.totalChange !== 0) {
       const sumPercent = result.categories.reduce(
-        (sum, c) => sum + c.percentImpact,
+        (sum, c) => sum + c.percentOfTotal,
         0
       );
       expect(sumPercent).toBeCloseTo(100, 0);
     }
   });
 
-  it("signs of change and percent impact are consistent", async () => {
+  it("child changes sum to parent change at each level", async () => {
     const result = await getNetWorthDrivers(thirtyDaysAgo, today);
 
-    if (result.totalChange !== 0) {
-      for (const cat of result.categories) {
-        if (cat.change !== 0) {
-          // If total change is positive, positive categories have positive impact
-          // If total change is negative, positive categories have negative impact
-          const sameSign =
-            Math.sign(cat.change) * Math.sign(result.totalChange) > 0;
-          expect(cat.percentImpact > 0).toBe(sameSign);
-        }
+    for (const cat of result.categories) {
+      const typesSum = cat.accountTypes.reduce((s, t) => s + t.change, 0);
+      expect(typesSum).toBeCloseTo(cat.change, 2);
+
+      for (const t of cat.accountTypes) {
+        const accSum = t.accounts.reduce((s, a) => s + a.change, 0);
+        expect(accSum).toBeCloseTo(t.change, 2);
       }
     }
+
+    const catSum = result.categories.reduce((s, c) => s + c.change, 0);
+    expect(catSum).toBeCloseTo(result.totalChange, 2);
   });
 });
 
@@ -128,6 +149,8 @@ describe("getNetWorthTrendDecomposition", () => {
     expect(first).toHaveProperty("date");
     expect(first).toHaveProperty("categoryId");
     expect(first).toHaveProperty("categoryName");
+    expect(first).toHaveProperty("accountTypeId");
+    expect(first).toHaveProperty("accountTypeName");
     expect(first).toHaveProperty("accountId");
     expect(first).toHaveProperty("accountName");
     expect(first).toHaveProperty("cumulativeBalance");


### PR DESCRIPTION
# Net Worth Dashboard Fixes & Enhancements (Issues #89–#92)

## Context
Four GitHub issues target the Net Worth drill-down page (`app/app/(app)/dashboard/net-worth/page.tsx`): one bug and three enhancements across the Waterfall chart, Net Worth Over Time timeseries chart, and Net Worth Drivers table.

---

## Issue #89 — Waterfall tooltip duplicate value
**File:** `app/components/charts/waterfall-chart.tsx`

**Root cause:** Two stacked `<Bar>` series (`base` transparent + `value` visible) both emit tooltip payload items; the custom `formatter` renders content for each → value prints twice.

**Change:** Filter the tooltip payload to `dataKey === "value"` so only the visible bar's row renders. No other logic changes.

---

## Issue #90 — "By Account Type" mode on Net Worth Over Time
**Files:**
- `app/lib/queries/net-worth-drilldown.ts`
- `app/components/charts/net-worth-timeseries-chart.tsx`

**Query change** (`getNetWorthTrendDecomposition`):
- Add `at.account_type_id`, `at.account_type` to the `SELECT` (join already present).
- Extend `DecompositionPoint` with `accountTypeId: number; accountTypeName: string`.

**Component change:**
- Widen `Mode` to `"net-worth" | "category" | "account-type" | "account"`.
- Add mode toggle option `{ value: "account-type", label: "By Account Type" }`.
- Extend `pivotDecomposition` to branch on the new mode using key `type_${accountTypeId}` with label `accountTypeName`.

---

## Issue #91 — Select All / Clear All legend controls
**File:** `app/components/charts/net-worth-timeseries-chart.tsx`

- Add two small text buttons next to the legend: **Select All** → `setHiddenSeries(new Set())`; **Clear All** → `setHiddenSeries(new Set(decomposed.series.map(s => s.key)))` (empty chart allowed; per user, this is an explicit action).
- Leave the existing `toggleSeries` ≥1-visible invariant intact for individual clicks — it still prevents accidental total-hide via single toggles.

---

## Issue #92 — Nested expandable rows in Net Worth Drivers table
**Files:**
- `app/lib/queries/net-worth-drilldown.ts` — extend `getNetWorthDrivers`
- `app/components/dashboard/net-worth-drivers-table.tsx` — convert to client component

**Query:** Return per-account start/end balances with `accountTypeId`, `accountTypeName`, `categoryId`, `categoryName`. Aggregate in TypeScript into three levels:

```ts
interface DriverAccount {
  accountId: number; accountName: string;
  change: number; percentOfParent: number; percentOfTotal: number;
}
interface DriverAccountType {
  accountTypeId: number; accountTypeName: string;
  change: number; percentOfParent: number; percentOfTotal: number;
  accounts: DriverAccount[];
}
interface DriverCategoryNested {
  categoryId: number; categoryName: string;
  change: number; percentOfTotal: number;
  accountTypes: DriverAccountType[];
}
```

**Percent basis (per user):** expose **both** — `% of Total` (share of overall `totalChange`) and `% of Parent` (share of immediate parent's change). Top-level category rows leave `% of Parent` blank (dash).

**Component:**
- Convert to `"use client"`; track `expanded: Set<string>` keyed `cat:{id}` / `type:{catId}:{typeId}`.
- Chevron icon (lucide `ChevronRight`/`ChevronDown`) in the first cell for expandable rows.
- Indent children via `pl-{n}` on the first cell (e.g. `pl-8`, `pl-14`).
- Sort children by `Math.abs(change)` desc (matches "drivers" intent).
- Preserve scroll position when expanding/collapsing so the clicked row stays anchored under the cursor.
- Reuse existing `formatCurrency`, `signedCurrency`, `signedPercent`, `valueColor` helpers in the same file.

---

## Verification
1. `cd app && npm run lint && npm run typecheck`.
2. Tests:
   - `npm run test:unit` — includes `app/tests/unit/components/waterfall-data-transform.test.ts`.
   - `npm run test:integration` — includes `app/tests/integration/queries/net-worth-drilldown.test.ts`. Extended for #90 (new fields) and #92 (nested structure + child-sums-to-parent invariants).
3. Start dev server (`npm run dev`) and open `/dashboard/net-worth`:
   - **#89**: hover a Waterfall bar → single value shown.
   - **#90**: switch to "By Account Type" → lines render, legend populated, tooltip labels correct.
   - **#91**: click Clear All → all lines hide; Select All → all restored; individual clicks still leave ≥1 visible.
   - **#92**: expand a Category row → account types; expand an account type → individual accounts; both % columns sum/compare correctly; totals unchanged.