### PR TITLE
Issue #95

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,15 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
 
-### 2026-04-14 — v0.1.1 (continued)
+### 2026-04-16 — v0.1.1 (continued)
+
+**Fix past-dated transactions breaking net worth balances (Issue #95)**
+- When a transaction was submitted for a past date, the net worth time series showed incorrect values for that date: Total Liabilities dropped to 0 and Total Assets reflected only the account that received the transaction
+- Root cause: `rebuildAccountBalance()` only rebuilds history for the affected account(s), and `ensureTodayBalances()` only carried forward balances for today — leaving other accounts with no balance rows for intermediate dates
+- Rewrote `ensureTodayBalances()` in `lib/queries/rebuild-balance.ts` to fill ALL missing gap dates (from each account's last balance row through today) using `CROSS JOIN LATERAL` + `generate_series`, instead of only filling today. Uses `ON CONFLICT DO NOTHING` so rows already created by `rebuildAccountBalance()` are never overwritten
+- Added integration tests for gap-filling behavior and non-overwrite of existing intermediate rows
+
+### 2026-04-14
 
 **Net Worth drill-down: nested drivers and By Account Type decomposition**
 - Net Worth Drivers table is now a 3-level expandable hierarchy: account type category → account type → account. Rows expand in place with chevron toggles and preserve scroll position across expands/collapses

--- a/app/lib/queries/rebuild-balance.ts
+++ b/app/lib/queries/rebuild-balance.ts
@@ -87,17 +87,29 @@ export async function ensureTodayBalances(): Promise<void> {
       (account_id, balance_date, daily_balance, cumulative_balance)
     SELECT
       a.account_id,
-      CURRENT_DATE,
+      d.gap_date,
       0,
       COALESCE(abh.cumulative_balance, 0)
     FROM accounts a
-    LEFT JOIN account_balance_history abh
-      ON abh.account_id = a.account_id
-      AND abh.balance_date = (
-        SELECT MAX(balance_date)
-        FROM account_balance_history
-        WHERE account_id = a.account_id
-      )
+    CROSS JOIN LATERAL (
+      SELECT generate_series(
+        COALESCE(
+          (SELECT MAX(balance_date) + INTERVAL '1 day'
+           FROM account_balance_history
+           WHERE account_id = a.account_id),
+          CURRENT_DATE
+        )::date,
+        CURRENT_DATE,
+        INTERVAL '1 day'
+      )::date AS gap_date
+    ) d
+    LEFT JOIN LATERAL (
+      SELECT cumulative_balance
+      FROM account_balance_history
+      WHERE account_id = a.account_id
+      ORDER BY balance_date DESC
+      LIMIT 1
+    ) abh ON true
     WHERE a.closed_date IS NULL
     ON CONFLICT (account_id, balance_date) DO NOTHING
   `);

--- a/app/tests/integration/queries/rebuild-balance.test.ts
+++ b/app/tests/integration/queries/rebuild-balance.test.ts
@@ -6,6 +6,8 @@ import { ensureTodayBalances } from "@/lib/queries/rebuild-balance";
 
 const today = new Date().toISOString().slice(0, 10);
 const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+const threeDaysAgo = new Date(Date.now() - 3 * 86_400_000).toISOString().slice(0, 10);
 
 // Track account IDs created during tests so we can clean them up
 const createdAccountIds: number[] = [];
@@ -145,6 +147,83 @@ describe("ensureTodayBalances", () => {
       );
 
     expect(rows).toHaveLength(0);
+  });
+
+  it("fills intermediate gap dates between last balance and today", async () => {
+    const [account] = await db
+      .insert(accounts)
+      .values({ accountName: "Gap Fill Test", accountTypeId: 1 })
+      .returning({ accountId: accounts.accountId });
+    createdAccountIds.push(account.accountId);
+
+    await db.insert(accountBalanceHistory).values({
+      accountId: account.accountId,
+      balanceDate: threeDaysAgo,
+      dailyBalance: "25.00",
+      cumulativeBalance: "750.00",
+    });
+
+    await ensureTodayBalances();
+
+    const rows = await db
+      .select()
+      .from(accountBalanceHistory)
+      .where(eq(accountBalanceHistory.accountId, account.accountId));
+
+    rows.sort((a, b) => a.balanceDate.localeCompare(b.balanceDate));
+
+    expect(rows).toHaveLength(4);
+    expect(rows[0].balanceDate).toBe(threeDaysAgo);
+    expect(rows[1].balanceDate).toBe(twoDaysAgo);
+    expect(rows[2].balanceDate).toBe(yesterday);
+    expect(rows[3].balanceDate).toBe(today);
+
+    for (const row of rows.slice(1)) {
+      expect(row.dailyBalance).toBe("0.00");
+      expect(row.cumulativeBalance).toBe("750.00");
+    }
+  });
+
+  it("does not overwrite rows created by rebuildAccountBalance for intermediate dates", async () => {
+    const [account] = await db
+      .insert(accounts)
+      .values({ accountName: "No Overwrite Test", accountTypeId: 1 })
+      .returning({ accountId: accounts.accountId });
+    createdAccountIds.push(account.accountId);
+
+    await db.insert(accountBalanceHistory).values([
+      {
+        accountId: account.accountId,
+        balanceDate: twoDaysAgo,
+        dailyBalance: "40.00",
+        cumulativeBalance: "400.00",
+      },
+      {
+        accountId: account.accountId,
+        balanceDate: yesterday,
+        dailyBalance: "60.00",
+        cumulativeBalance: "460.00",
+      },
+    ]);
+
+    await ensureTodayBalances();
+
+    const rows = await db
+      .select()
+      .from(accountBalanceHistory)
+      .where(eq(accountBalanceHistory.accountId, account.accountId));
+
+    rows.sort((a, b) => a.balanceDate.localeCompare(b.balanceDate));
+
+    expect(rows).toHaveLength(3);
+
+    expect(rows[1].balanceDate).toBe(yesterday);
+    expect(rows[1].dailyBalance).toBe("60.00");
+    expect(rows[1].cumulativeBalance).toBe("460.00");
+
+    expect(rows[2].balanceDate).toBe(today);
+    expect(rows[2].dailyBalance).toBe("0.00");
+    expect(rows[2].cumulativeBalance).toBe("460.00");
   });
 
   it("defaults to 0 cumulative balance for accounts with no history", async () => {


### PR DESCRIPTION
Summary: Updated ensureTodayBalances() in [rebuild-balance.ts](vscode-webview://0i3r7hrdlfps7uvaomhgj2atqbh7varomv6m233tev86f3nlqhi4/app/lib/queries/rebuild-balance.ts) to fill ALL missing gap dates between each account's last balance row and today, instead of only filling today. This ensures that when a past-dated transaction rebuilds one account's history, all other accounts also have balance rows for that date on the next dashboard load. Added two new test cases confirming gap-filling and non-overwrite behavior.