### PR TITLE
Issue #97

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,15 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
 
-### 2026-04-16 — v0.1.1 (continued)
+### 2026-04-16 — v0.1.2 (in progress)
+
+**Make Net Worth KPI and chart obviously clickable (Issue #97)**
+- Net Worth headline KPI on the Summary page already linked to the drill-down, but the only affordance was `hover:opacity-80` and most users didn't realise it was clickable. Replaced with a visible `hover:bg-accent` background and a `ChevronRight` icon next to the label that nudges right on hover
+- Net Worth time-series chart in "Historical Trends" is now clickable too — the entire card navigates to `/dashboard/net-worth`, with a hover ring + shadow and a chevron in the title
+- Added an optional `href` prop to the `TimeSeriesChart` component so future drill-downs (Total Assets, Total Liabilities, gauge KPIs) can be wired up the same way once those pages exist
+- Total Assets and Total Liabilities charts are unchanged — left non-clickable on purpose so the affordance stays meaningful (only clickable things look clickable)
+
+### 2026-04-16 — v0.1.1
 
 **Fix past-dated transactions breaking net worth balances (Issue #95)**
 - When a transaction was submitted for a past date, the net worth time series showed incorrect values for that date: Total Liabilities dropped to 0 and Total Assets reflected only the account that received the transaction
@@ -351,7 +359,7 @@ Data is persisted in Docker volumes and will be available on next startup.
 - Drill-down page layout: Drivers table is now full-width; Time Series and Waterfall sit side-by-side at a fixed height. Waterfall tooltip no longer double-lists the value row
 - Integration tests updated to assert the nested drivers shape, that child changes sum to parent change at every level, that category `% of Total` sums to ~100, and that decomposition points expose the new account-type fields
 
-### 2026-04-12 — v0.1.1 (continued)
+### 2026-04-12
 
 **Net Worth drill-down page**
 - Added `/dashboard/net-worth` drill-down page accessible by clicking the Net Worth KPI on the Summary page

--- a/app/app/(app)/dashboard/page.tsx
+++ b/app/app/(app)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import {
   getCurrentNetWorth,
   getNetWorthTimeSeries,
@@ -93,10 +94,11 @@ export default async function DashboardSummaryPage({
             {/* Net Worth headline — links to drill-down */}
             <Link
               href="/dashboard/net-worth"
-              className="flex flex-col justify-center gap-1 shrink-0 lg:min-w-[280px] rounded-md transition-opacity hover:opacity-80"
+              className="group flex flex-col justify-center gap-1 shrink-0 lg:min-w-[280px] -mx-3 px-3 py-2 rounded-md transition-colors hover:bg-accent"
             >
-              <span className="text-sm font-medium text-muted-foreground">
+              <span className="flex items-center gap-1 text-sm font-medium text-muted-foreground">
                 Net Worth
+                <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
               </span>
               <span className="text-5xl font-bold tabular-nums tracking-tight">
                 {formatCurrency(summary.netWorth)}
@@ -165,6 +167,7 @@ export default async function DashboardSummaryPage({
               data={timeSeries}
               dataKey="netWorth"
               color={COLORS.netWorth}
+              href="/dashboard/net-worth"
             />
             <TimeSeriesChart
               title="Total Assets"

--- a/app/components/charts/net-worth-chart.tsx
+++ b/app/components/charts/net-worth-chart.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { format } from "date-fns";
+import { ChevronRight } from "lucide-react";
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 import type { TimeSeriesPoint } from "@/lib/queries/dashboard";
 import {
@@ -21,6 +23,7 @@ interface TimeSeriesChartProps {
   data: TimeSeriesPoint[];
   dataKey: "netWorth" | "totalAssets" | "totalLiabilities";
   color: string;
+  href?: string;
 }
 
 // Compact format for Y-axis ticks (e.g. "$300K")
@@ -51,6 +54,7 @@ export function TimeSeriesChart({
   data,
   dataKey,
   color,
+  href,
 }: TimeSeriesChartProps) {
   const chartConfig: ChartConfig = {
     [dataKey]: {
@@ -59,10 +63,21 @@ export function TimeSeriesChart({
     },
   };
 
-  return (
-    <Card>
+  const card = (
+    <Card
+      className={
+        href
+          ? "h-full cursor-pointer transition-shadow hover:ring-2 hover:ring-primary/40 hover:shadow-md"
+          : undefined
+      }
+    >
       <CardHeader>
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <CardTitle className="flex items-center justify-between text-sm font-medium">
+          <span>{title}</span>
+          {href ? (
+            <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-hover/chart-link:translate-x-0.5" />
+          ) : null}
+        </CardTitle>
       </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig} className="aspect-[2/1] w-full">
@@ -108,4 +123,14 @@ export function TimeSeriesChart({
       </CardContent>
     </Card>
   );
+
+  if (href) {
+    return (
+      <Link href={href} className="group/chart-link block">
+        {card}
+      </Link>
+    );
+  }
+
+  return card;
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-stack",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-stack",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@tanstack/react-table": "^8.21.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-stack",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3001",


### PR DESCRIPTION
## Summary

Makes the Net Worth KPI and time-series chart on the dashboard Summary page obviously clickable, so users can discover the existing `/dashboard/net-worth` drill-down. Closes #97. Version bumped to v0.1.2.

## Changes

- **Net Worth KPI** ([`app/app/(app)/dashboard/page.tsx`](app/app/(app)/dashboard/page.tsx)): swapped the subtle `hover:opacity-80` for a visible `hover:bg-accent` background with padding, and added a `ChevronRight` icon next to the label that nudges right on hover.
- **TimeSeriesChart** ([`app/components/charts/net-worth-chart.tsx`](app/components/charts/net-worth-chart.tsx)): added an optional `href` prop. When set, the whole `Card` is wrapped in a `<Link>` with a hover ring + shadow and a chevron in the title. No behaviour change when `href` is unset.
- **Dashboard wiring** ([`app/app/(app)/dashboard/page.tsx`](app/app/(app)/dashboard/page.tsx)): passed `href="/dashboard/net-worth"` to the Net Worth chart only. Total Assets and Total Liabilities charts left unchanged on purpose — they have no drill-down yet, and keeping them non-clickable preserves the affordance's meaning.
- **Version bump**: `app/package.json` and `app/package-lock.json` → `0.1.2`, with matching changelog entry in `README.md`.

## Test plan

- [x] `/dashboard` loads; hover the Net Worth KPI → background changes, chevron slides right, cursor is pointer
- [x] Click the Net Worth KPI → navigates to `/dashboard/net-worth`
- [x] Hover the Net Worth chart card in "Historical Trends" → ring + shadow appear, chevron visible in title
- [x] Click anywhere on the Net Worth chart card → navigates to `/dashboard/net-worth`
- [x] Hovering a data point in the Net Worth chart still shows the Recharts tooltip (Link wrapper should not swallow pointer events)
- [x] Total Assets and Total Liabilities chart cards show no hover affordance and are not clickable
- [x] `npm run typecheck` and `npm run lint` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)