### PR TITLE
Issue #102 - Assets drilldown page + liquidity classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ finance-stack/
 │   │       │   ├── layout.tsx            #     Layout with tab navigation
 │   │       │   ├── page.tsx              #     Summary tab (/)
 │   │       │   ├── net-worth/            #     Net Worth drill-down (from Summary KPI click)
+│   │       │   ├── assets/               #     Assets drill-down (allocation, performance, liquidity, trend)
 │   │       │   ├── accounting/           #     Personal Accounting tab
 │   │       │   ├── transactions/         #     Transactions tab (form + list)
 │   │       │   ├── accounts/             #     Accounts tab (visual balance sheet)
@@ -229,6 +230,8 @@ finance-stack/
 │   │   │   ├── net-worth-chart.tsx       # Reusable time-series line chart (Recharts)
 │   │   │   ├── waterfall-chart.tsx       # Net worth waterfall analysis chart (Recharts)
 │   │   │   ├── trend-decomposition-chart.tsx # Multi-series trend decomposition by category/account (Recharts)
+│   │   │   ├── asset-allocation-chart.tsx # Treemap of assets by category → account type (Recharts)
+│   │   │   ├── assets-timeseries-chart.tsx # Stacked area chart of asset balances by category (Recharts)
 │   │   │   └── gauge-badge.tsx           # Custom SVG semicircular gauge with range segments
 │   │   ├── accounts/                     # Accounts page components
 │   │   │   ├── accounts-table.tsx        # Two-column balance sheet with expand/collapse; exports amountColorClass()
@@ -245,6 +248,8 @@ finance-stack/
 │   │   │   ├── accounting-kpi-card.tsx   # KPI card with change indicator for accounting metrics
 │   │   │   ├── date-range-filter.tsx     # URL-param-driven date range filter wrapper
 │   │   │   ├── net-worth-drivers-table.tsx # Expandable net worth drivers table (category → account type → account)
+│   │   │   ├── asset-performance-table.tsx # Expandable assets performance table (category → account type → account)
+│   │   │   ├── liquidity-breakdown.tsx   # Liquidity classification tiles + stacked bar
 │   │   │   └── summary-drilldown-tabs.tsx # Sub-navigation tabs for Summary drill-down pages
 │   │   └── transactions/                 # Transaction-specific components
 │   │       ├── transaction-form.tsx      # Transaction entry form (client component)
@@ -262,6 +267,7 @@ finance-stack/
 │       ├── queries/work-expenses.ts     # Work expense queries (period totals, time series, category breakdown)
 │       ├── queries/dashboard.ts          # Dashboard queries (net worth, time series)
 │       ├── queries/net-worth-drilldown.ts # Net worth drill-down queries (waterfall, drivers, decomposition)
+│       ├── queries/assets-drilldown.ts   # Assets drill-down queries (allocation, performance, liquidity, decomposition)
 │       ├── queries/rebuild-balance.ts    # Per-account balance history rebuild
 │       ├── queries/transactions.ts       # Transaction queries (filtered, sorted, form options)
 │       ├── validations/transaction.ts    # Zod schema for transaction form validation
@@ -338,7 +344,18 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
 
-### 2026-04-18 — v0.1.2 (in progress)
+### 2026-04-19 — v0.1.2 (in progress)
+
+**Assets drilldown page + liquidity classification (Issue #102)**
+- New page at `/dashboard/assets` surfaces asset allocation (treemap by category → account type), period-over-period performance (hierarchical category → type → account table), liquidity breakdown, and a stacked time-series decomposition. Triggered from the Total Assets chart and the Assets-per-$-of-Debt gauge on the Summary tab, or via a new Assets tab in `SummaryDrilldownTabs`.
+- New `liquidity_class` column on `account_types` (default, seeded for all asset types) and `accounts` (nullable per-account override). Queries resolve the effective liquidity via `COALESCE(a.liquidity_class, at.liquidity_class)`. Liabilities remain NULL.
+- Account creation / edit form gains a Liquidity dropdown with "Inherit from type" default; when a type is selected, the form shows that type's default liquidity as helper text.
+- New query module `app/lib/queries/assets-drilldown.ts` mirrors the net-worth drill-down pattern with `getAssetAllocation`, `getAssetPerformance`, `getLiquidityBreakdown`, and `getAssetTrendDecomposition`.
+- Performance "return" is proxied by `cumulative_balance` delta (consistent with the net-worth drivers table) — there is no cost-basis schema in v1.
+- Fresh installs get the new columns via `init-db/schema.sql`; the `vitest-setup.ts` `ALTER TABLE … ADD COLUMN IF NOT EXISTS` guard covers already-running test DBs so no manual rebuild is needed.
+- Added integration tests for all four new queries and three new account-action cases covering the `liquidity_class` override lifecycle; added unit tests for the liquidity-tile projector and the signed-currency/percent/color helpers.
+
+### 2026-04-18
 
 **Editable Transactions table — inline row edit and single-row delete (Issue #99)**
 - Each row in the Transactions table now exposes a Pencil and a Trash icon. Pencil flips the row into an inline edit form covering Date, Description, Amount, Account, Related Account, Type, and Category — Save / Cancel buttons commit or discard. Trash opens a confirmation dialog showing the row's date, description, and amount before deletion.

--- a/app/app/(app)/dashboard/assets/page.tsx
+++ b/app/app/(app)/dashboard/assets/page.tsx
@@ -1,0 +1,91 @@
+import {
+  getAssetAllocation,
+  getAssetPerformance,
+  getLiquidityBreakdown,
+  getAssetTrendDecomposition,
+} from "@/lib/queries/assets-drilldown";
+import { AssetAllocationChart } from "@/components/charts/asset-allocation-chart";
+import { AssetsTimeSeriesChart } from "@/components/charts/assets-timeseries-chart";
+import { AssetPerformanceTable } from "@/components/dashboard/asset-performance-table";
+import { LiquidityBreakdown } from "@/components/dashboard/liquidity-breakdown";
+import { SummaryDrilldownTabs } from "@/components/dashboard/summary-drilldown-tabs";
+import { DashboardDateRangeFilter } from "@/components/dashboard/date-range-filter";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(n);
+
+export default async function AssetsDrilldownPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+
+  const defaultFrom = new Date();
+  defaultFrom.setDate(defaultFrom.getDate() - 30);
+  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
+
+  const dateFrom =
+    (Array.isArray(params.dateFrom) ? params.dateFrom[0] : params.dateFrom) ||
+    defaultFromStr;
+  const dateTo =
+    (Array.isArray(params.dateTo) ? params.dateTo[0] : params.dateTo) ||
+    undefined;
+
+  const [allocation, performance, liquidity, decomposition] = await Promise.all(
+    [
+      getAssetAllocation(dateTo),
+      getAssetPerformance(dateFrom, dateTo),
+      getLiquidityBreakdown(dateTo),
+      getAssetTrendDecomposition(dateFrom, dateTo),
+    ]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <SummaryDrilldownTabs />
+        <div className="mt-4 flex items-center justify-between">
+          <h1 className="text-2xl font-bold tracking-tight">Asset Analysis</h1>
+          <DashboardDateRangeFilter basePath="/dashboard/assets" />
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Total Assets</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <span className="text-5xl font-bold tabular-nums tracking-tight">
+            {formatCurrency(allocation.totalAssets)}
+          </span>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="h-[500px]">
+          <AssetAllocationChart data={allocation} />
+        </div>
+        <div className="h-[500px]">
+          <AssetsTimeSeriesChart decomposition={decomposition} />
+        </div>
+      </div>
+
+      <LiquidityBreakdown data={liquidity} />
+
+      <AssetPerformanceTable data={performance} />
+    </div>
+  );
+}

--- a/app/app/(app)/dashboard/page.tsx
+++ b/app/app/(app)/dashboard/page.tsx
@@ -107,19 +107,24 @@ export default async function DashboardSummaryPage({
 
             {/* Gauge badges row */}
             <div className="flex flex-1 items-center justify-evenly gap-4">
-              <GaugeBadge
-                title="Assets per $ of Debt"
-                label={`$${assetToLiability.toFixed(2)}`}
-                value={assetToLiability}
-                min={0}
-                max={3}
-                segments={[
-                  { max: 1, color: RANGE_COLORS.red },
-                  { max: 1.5, color: RANGE_COLORS.yellow },
-                  { max: 2, color: RANGE_COLORS.green },
-                  { max: 3, color: RANGE_COLORS.blue },
-                ]}
-              />
+              <Link
+                href="/dashboard/assets"
+                className="group rounded-md p-2 transition-colors hover:bg-accent"
+              >
+                <GaugeBadge
+                  title="Assets per $ of Debt"
+                  label={`$${assetToLiability.toFixed(2)}`}
+                  value={assetToLiability}
+                  min={0}
+                  max={3}
+                  segments={[
+                    { max: 1, color: RANGE_COLORS.red },
+                    { max: 1.5, color: RANGE_COLORS.yellow },
+                    { max: 2, color: RANGE_COLORS.green },
+                    { max: 3, color: RANGE_COLORS.blue },
+                  ]}
+                />
+              </Link>
               <GaugeBadge
                 title="% Owned Assets"
                 label={`${nwToAsset.toFixed(2)}%`}
@@ -174,6 +179,7 @@ export default async function DashboardSummaryPage({
               data={timeSeries}
               dataKey="totalAssets"
               color={COLORS.assets}
+              href="/dashboard/assets"
             />
             <TimeSeriesChart
               title="Total Liabilities"

--- a/app/components/accounts/account-form.tsx
+++ b/app/components/accounts/account-form.tsx
@@ -19,6 +19,13 @@ import {
   ComboboxCollection,
   ComboboxEmpty,
 } from "@/components/ui/combobox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import { createAccount, updateAccount } from "@/lib/actions/account";
 
@@ -39,6 +46,10 @@ interface LookupOption {
   name: string;
 }
 
+interface AccountTypeOption extends LookupOption {
+  liquidityClass: string | null;
+}
+
 interface AccountData {
   accountId: number;
   accountName: string;
@@ -46,13 +57,30 @@ interface AccountData {
   accountIdentifier: string | null;
   openedDate: string | null;
   closedDate: string | null;
+  liquidityClass: string | null;
 }
 
 interface AccountFormProps {
-  accountTypes: LookupOption[];
+  accountTypes: AccountTypeOption[];
   account?: AccountData;
   defaultTypeId?: number;
 }
+
+const LIQUIDITY_LABELS: Record<string, string> = {
+  liquid: "Liquid",
+  semi_liquid: "Semi-liquid",
+  illiquid: "Illiquid",
+  restricted: "Restricted",
+};
+
+const LIQUIDITY_OPTIONS = [
+  { value: "liquid", label: "Liquid" },
+  { value: "semi_liquid", label: "Semi-liquid" },
+  { value: "illiquid", label: "Illiquid" },
+  { value: "restricted", label: "Restricted" },
+] as const;
+
+const INHERIT_SENTINEL = "inherit";
 
 function SubmitButton({ isEdit }: { isEdit: boolean }) {
   const { pending } = useFormStatus();
@@ -143,6 +171,14 @@ export function AccountForm({ accountTypes, account, defaultTypeId }: AccountFor
   const [openedDate, setOpenedDate] = useState(account?.openedDate ?? "");
   const [closedDate, setClosedDate] = useState(account?.closedDate ?? "");
   const [initialBalance, setInitialBalance] = useState("");
+  const [liquidityClass, setLiquidityClass] = useState<string>(
+    account?.liquidityClass ?? INHERIT_SENTINEL
+  );
+
+  const selectedType = accountTypes.find(
+    (t) => String(t.id) === accountTypeId
+  );
+  const typeDefaultLiquidity = selectedType?.liquidityClass ?? null;
 
   useEffect(() => {
     if (state.message) {
@@ -188,6 +224,41 @@ export function AccountForm({ accountTypes, account, defaultTypeId }: AccountFor
         required
         error={state.errors.accountTypeId}
       />
+
+      <div className="space-y-2">
+        <Label htmlFor="liquidityClass">Liquidity</Label>
+        <input
+          type="hidden"
+          name="liquidityClass"
+          value={liquidityClass === INHERIT_SENTINEL ? "" : liquidityClass}
+        />
+        <Select
+          value={liquidityClass}
+          onValueChange={(val) => setLiquidityClass(val ?? INHERIT_SENTINEL)}
+        >
+          <SelectTrigger id="liquidityClass" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={INHERIT_SENTINEL}>Inherit from type</SelectItem>
+            {LIQUIDITY_OPTIONS.map(({ value, label }) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {typeDefaultLiquidity && (
+          <p className="text-xs text-muted-foreground">
+            Default for this type: {LIQUIDITY_LABELS[typeDefaultLiquidity] ?? typeDefaultLiquidity}
+          </p>
+        )}
+        {state.errors.liquidityClass && (
+          <p className="text-sm text-destructive">
+            {state.errors.liquidityClass[0]}
+          </p>
+        )}
+      </div>
 
       <div className="space-y-2">
         <Label htmlFor="accountIdentifier">Account Identifier</Label>

--- a/app/components/charts/asset-allocation-chart.tsx
+++ b/app/components/charts/asset-allocation-chart.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useMemo } from "react";
+import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
+import type { AllocationData } from "@/lib/queries/assets-drilldown";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const CATEGORY_COLORS: Record<number, string> = {
+  1: "#2eb88a", // Current Asset
+  2: "#8b5cf6", // Restricted Asset
+  3: "#eab308", // Fixed Asset
+  4: "#2662d9", // Investment
+};
+
+const formatCurrencyCompact = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+
+const formatCurrencyFull = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+interface TreemapNode {
+  name: string;
+  size?: number;
+  categoryId?: number;
+  categoryName?: string;
+  percentOfTotal?: number;
+  percentOfParent?: number;
+  children?: TreemapNode[];
+}
+
+interface AssetAllocationChartProps {
+  data: AllocationData;
+}
+
+interface ContentProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  name?: string;
+  size?: number;
+  categoryId?: number;
+  categoryName?: string;
+  percentOfTotal?: number;
+  depth?: number;
+  root?: { children?: TreemapNode[] };
+}
+
+function TreemapContent(props: ContentProps) {
+  const { x = 0, y = 0, width = 0, height = 0, depth, name, size, categoryId, percentOfTotal } = props;
+
+  // Depth 0 = virtual root; depth 1 = category (hidden, only used for grouping);
+  // depth 2 = leaf (account type).
+  if (depth !== 2) {
+    return <g />;
+  }
+
+  const color = categoryId ? CATEGORY_COLORS[categoryId] ?? "#6b7280" : "#6b7280";
+  const canLabel = width > 70 && height > 32;
+  const canDetails = width > 90 && height > 52;
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        style={{
+          fill: color,
+          stroke: "#fff",
+          strokeWidth: 2,
+          strokeOpacity: 0.8,
+        }}
+      />
+      {canLabel && (
+        <text
+          x={x + 6}
+          y={y + 16}
+          fill="#fff"
+          fontSize={11}
+          fontWeight={600}
+        >
+          {name}
+        </text>
+      )}
+      {canDetails && size != null && (
+        <text x={x + 6} y={y + 32} fill="#fff" fontSize={10} opacity={0.85}>
+          {formatCurrencyCompact(size)}
+          {percentOfTotal != null ? ` · ${percentOfTotal.toFixed(1)}%` : ""}
+        </text>
+      )}
+    </g>
+  );
+}
+
+interface TreemapTooltipPayload {
+  name?: string;
+  size?: number;
+  categoryName?: string;
+  percentOfTotal?: number;
+  percentOfParent?: number;
+}
+
+function TreemapTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload?: TreemapTooltipPayload }[];
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const datum = payload[0].payload;
+  if (!datum || datum.size == null) return null;
+  return (
+    <div className="rounded-md border bg-popover px-3 py-2 text-xs shadow-md">
+      <div className="font-medium">{datum.name}</div>
+      {datum.categoryName && (
+        <div className="text-muted-foreground">{datum.categoryName}</div>
+      )}
+      <div className="mt-1 tabular-nums">
+        {formatCurrencyFull(datum.size)}
+      </div>
+      {datum.percentOfTotal != null && (
+        <div className="text-muted-foreground tabular-nums">
+          {datum.percentOfTotal.toFixed(2)}% of total
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AssetAllocationChart({ data }: AssetAllocationChartProps) {
+  const treeData: TreemapNode[] = useMemo(() => {
+    return data.byCategory.map((cat) => ({
+      name: cat.categoryName,
+      categoryId: cat.categoryId,
+      categoryName: cat.categoryName,
+      children: cat.children.map((child) => ({
+        name: child.accountTypeName,
+        size: child.value,
+        categoryId: cat.categoryId,
+        categoryName: cat.categoryName,
+        percentOfTotal: child.percentOfTotal,
+        percentOfParent: child.percentOfParent,
+      })),
+    }));
+  }, [data]);
+
+  const isEmpty = data.byCategory.length === 0 || data.totalAssets === 0;
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Asset Allocation</CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-3">
+        <div className="min-h-0 flex-1">
+          {isEmpty ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              No asset balances in the selected range.
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <Treemap
+                data={treeData}
+                dataKey="size"
+                nameKey="name"
+                stroke="#fff"
+                isAnimationActive={false}
+                content={<TreemapContent />}
+              >
+                <Tooltip content={<TreemapTooltip />} />
+              </Treemap>
+            </ResponsiveContainer>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-1 text-xs text-muted-foreground">
+          {data.byCategory.map((cat) => (
+            <div key={cat.categoryId} className="flex items-center gap-1.5">
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: CATEGORY_COLORS[cat.categoryId] ?? "#6b7280" }}
+                aria-hidden
+              />
+              <span>
+                {cat.categoryName} · {cat.percentOfTotal.toFixed(1)}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/charts/assets-timeseries-chart.tsx
+++ b/app/components/charts/assets-timeseries-chart.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useMemo } from "react";
+import { format } from "date-fns";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { AssetDecompositionPoint } from "@/lib/queries/assets-drilldown";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const CATEGORY_COLORS: Record<number, string> = {
+  1: "#2eb88a",
+  2: "#8b5cf6",
+  3: "#eab308",
+  4: "#2662d9",
+};
+
+const formatCurrencyCompact = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+
+const formatCurrencyFull = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const formatDate = (dateStr: string) => {
+  const d = new Date(dateStr + "T00:00:00");
+  return format(d, "MMM d");
+};
+
+interface SeriesInfo {
+  key: string;
+  label: string;
+  color: string;
+  categoryId: number;
+}
+
+interface PivotedRow {
+  date: string;
+  [seriesKey: string]: number | string;
+}
+
+function pivotByCategory(points: AssetDecompositionPoint[]): {
+  rows: PivotedRow[];
+  series: SeriesInfo[];
+} {
+  const seriesMap = new Map<number, SeriesInfo>();
+  for (const p of points) {
+    if (!seriesMap.has(p.categoryId)) {
+      seriesMap.set(p.categoryId, {
+        key: `cat_${p.categoryId}`,
+        label: p.categoryName,
+        color: CATEGORY_COLORS[p.categoryId] ?? "#6b7280",
+        categoryId: p.categoryId,
+      });
+    }
+  }
+
+  const series = Array.from(seriesMap.values()).sort(
+    (a, b) => a.categoryId - b.categoryId
+  );
+
+  const dateMap = new Map<string, PivotedRow>();
+  for (const p of points) {
+    if (!dateMap.has(p.date)) {
+      const row: PivotedRow = { date: p.date };
+      for (const s of series) row[s.key] = 0;
+      dateMap.set(p.date, row);
+    }
+    const row = dateMap.get(p.date)!;
+    const key = `cat_${p.categoryId}`;
+    row[key] = ((row[key] as number) || 0) + p.cumulativeBalance;
+  }
+
+  const rows = Array.from(dateMap.values()).sort((a, b) =>
+    a.date.localeCompare(b.date)
+  );
+
+  return { rows, series };
+}
+
+interface AssetsTimeSeriesChartProps {
+  decomposition: AssetDecompositionPoint[];
+}
+
+export function AssetsTimeSeriesChart({
+  decomposition,
+}: AssetsTimeSeriesChartProps) {
+  const { rows, series } = useMemo(
+    () => pivotByCategory(decomposition),
+    [decomposition]
+  );
+
+  const chartConfig: ChartConfig = Object.fromEntries(
+    series.map((s) => [s.key, { label: s.label, color: s.color }])
+  );
+
+  const isEmpty = rows.length === 0;
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          Assets Over Time (by category)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col">
+        {isEmpty ? (
+          <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+            No asset balance history in the selected range.
+          </div>
+        ) : (
+          <ChartContainer config={chartConfig} className="min-h-0 flex-1 w-full">
+            <AreaChart data={rows} margin={{ left: 8, right: 8 }}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="date"
+                tickFormatter={formatDate}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={32}
+              />
+              <YAxis
+                tickFormatter={formatCurrencyCompact}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={60}
+                domain={["auto", "auto"]}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(_, payload) => {
+                      if (!payload?.[0]?.payload?.date) return "";
+                      const d = new Date(
+                        payload[0].payload.date + "T00:00:00"
+                      );
+                      return format(d, "MMM d, yyyy");
+                    }}
+                    formatter={(value, name) => (
+                      <div className="flex flex-1 justify-between gap-4">
+                        <span className="font-bold">
+                          {chartConfig[name as string]?.label ?? name}:
+                        </span>
+                        <span className="tabular-nums">
+                          {formatCurrencyFull(value as number)}
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              {series.map((s) => (
+                <Area
+                  key={s.key}
+                  type="monotone"
+                  dataKey={s.key}
+                  stackId="assets"
+                  stroke={s.color}
+                  fill={s.color}
+                  fillOpacity={0.4}
+                  strokeWidth={2}
+                />
+              ))}
+            </AreaChart>
+          </ChartContainer>
+        )}
+        <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-3 text-xs text-muted-foreground">
+          {series.map((s) => (
+            <div key={s.key} className="flex items-center gap-1.5">
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: s.color }}
+                aria-hidden
+              />
+              <span>{s.label}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/dashboard/asset-performance-table.tsx
+++ b/app/components/dashboard/asset-performance-table.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import type { PerformanceData } from "@/lib/queries/assets-drilldown";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+
+export function signedCurrency(n: number): string {
+  const formatted = formatCurrency(Math.abs(n));
+  if (n > 0) return `+${formatted}`;
+  if (n < 0) return `-${formatted}`;
+  return formatted;
+}
+
+export function signedPercent(n: number): string {
+  const abs = Math.abs(n).toFixed(2);
+  if (n > 0) return `+${abs}%`;
+  if (n < 0) return `-${abs}%`;
+  return `${abs}%`;
+}
+
+export function changeColor(n: number): string {
+  if (n > 0) return "text-green-600 dark:text-green-400";
+  if (n < 0) return "text-red-600 dark:text-red-400";
+  return "";
+}
+
+interface AssetPerformanceTableProps {
+  data: PerformanceData;
+}
+
+export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const rowRefs = useRef<Map<string, HTMLTableRowElement | null>>(new Map());
+  const pendingScroll = useRef<{ key: string; top: number } | null>(null);
+
+  const toggle = (key: string) => {
+    const row = rowRefs.current.get(key);
+    if (row) {
+      pendingScroll.current = {
+        key,
+        top: row.getBoundingClientRect().top,
+      };
+    }
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  useLayoutEffect(() => {
+    const pending = pendingScroll.current;
+    if (!pending) return;
+    const row = rowRefs.current.get(pending.key);
+    if (row) {
+      const delta = row.getBoundingClientRect().top - pending.top;
+      if (delta !== 0) window.scrollBy(0, delta);
+    }
+    pendingScroll.current = null;
+  }, [expanded]);
+
+  const setRowRef = (key: string) => (el: HTMLTableRowElement | null) => {
+    if (el) rowRefs.current.set(key, el);
+    else rowRefs.current.delete(key);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Asset Performance</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead className="text-right">Value</TableHead>
+              <TableHead className="text-right">Change</TableHead>
+              <TableHead className="text-right">% Change</TableHead>
+              <TableHead className="text-right">% of Total</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.categories.map((cat) => {
+              const catKey = `cat:${cat.categoryId}`;
+              const catOpen = expanded.has(catKey);
+              const Chevron = catOpen ? ChevronDown : ChevronRight;
+              return (
+                <Fragment key={catKey}>
+                  <TableRow
+                    ref={setRowRef(catKey)}
+                    className="cursor-pointer"
+                    onClick={() => toggle(catKey)}
+                    data-testid={`row-${catKey}`}
+                  >
+                    <TableCell className="text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
+                        <Chevron className="h-4 w-4" />
+                        {cat.categoryName}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCurrency(cat.currentValue)}
+                    </TableCell>
+                    <TableCell
+                      className={`text-right tabular-nums ${changeColor(cat.change)}`}
+                    >
+                      {signedCurrency(cat.change)}
+                    </TableCell>
+                    <TableCell
+                      className={`text-right tabular-nums ${changeColor(cat.percentChange)}`}
+                    >
+                      {signedPercent(cat.percentChange)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {cat.percentOfTotal.toFixed(2)}%
+                    </TableCell>
+                  </TableRow>
+                  {catOpen &&
+                    cat.accountTypes.map((type) => {
+                      const typeKey = `type:${cat.categoryId}:${type.accountTypeId}`;
+                      const typeOpen = expanded.has(typeKey);
+                      const TypeChevron = typeOpen
+                        ? ChevronDown
+                        : ChevronRight;
+                      return (
+                        <Fragment key={typeKey}>
+                          <TableRow
+                            ref={setRowRef(typeKey)}
+                            className="cursor-pointer"
+                            onClick={() => toggle(typeKey)}
+                            data-testid={`row-${typeKey}`}
+                          >
+                            <TableCell className="text-muted-foreground pl-8">
+                              <span className="inline-flex items-center gap-1">
+                                <TypeChevron className="h-4 w-4" />
+                                {type.accountTypeName}
+                              </span>
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {formatCurrency(type.currentValue)}
+                            </TableCell>
+                            <TableCell
+                              className={`text-right tabular-nums ${changeColor(type.change)}`}
+                            >
+                              {signedCurrency(type.change)}
+                            </TableCell>
+                            <TableCell
+                              className={`text-right tabular-nums ${changeColor(type.percentChange)}`}
+                            >
+                              {signedPercent(type.percentChange)}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {type.percentOfTotal.toFixed(2)}%
+                            </TableCell>
+                          </TableRow>
+                          {typeOpen &&
+                            type.accounts.map((acc) => (
+                              <TableRow
+                                key={`acc:${cat.categoryId}:${type.accountTypeId}:${acc.accountId}`}
+                                data-testid={`row-acc:${acc.accountId}`}
+                              >
+                                <TableCell className="text-muted-foreground pl-14">
+                                  {acc.accountName}
+                                </TableCell>
+                                <TableCell className="text-right tabular-nums">
+                                  {formatCurrency(acc.currentValue)}
+                                </TableCell>
+                                <TableCell
+                                  className={`text-right tabular-nums ${changeColor(acc.change)}`}
+                                >
+                                  {signedCurrency(acc.change)}
+                                </TableCell>
+                                <TableCell
+                                  className={`text-right tabular-nums ${changeColor(acc.percentChange)}`}
+                                >
+                                  {signedPercent(acc.percentChange)}
+                                </TableCell>
+                                <TableCell className="text-right tabular-nums">
+                                  {acc.percentOfTotal.toFixed(2)}%
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                        </Fragment>
+                      );
+                    })}
+                </Fragment>
+              );
+            })}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableCell className="font-bold">Total</TableCell>
+              <TableCell className="text-right font-bold tabular-nums">
+                {formatCurrency(data.totalCurrentValue)}
+              </TableCell>
+              <TableCell
+                className={`text-right font-bold tabular-nums ${changeColor(data.totalChange)}`}
+              >
+                {signedCurrency(data.totalChange)}
+              </TableCell>
+              <TableCell
+                className={`text-right font-bold tabular-nums ${changeColor(data.totalPercentChange)}`}
+              >
+                {signedPercent(data.totalPercentChange)}
+              </TableCell>
+              <TableCell className="text-right font-bold tabular-nums">
+                {data.totalCurrentValue > 0 ? "100.00%" : "0.00%"}
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/dashboard/liquidity-breakdown.tsx
+++ b/app/components/dashboard/liquidity-breakdown.tsx
@@ -1,0 +1,165 @@
+import type {
+  LiquidityClass,
+  LiquidityData,
+} from "@/lib/queries/assets-drilldown";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const CLASS_META: Record<
+  LiquidityClass,
+  { label: string; color: string; description: string }
+> = {
+  liquid: {
+    label: "Liquid",
+    color: "#2eb88a",
+    description: "Cash and equivalents",
+  },
+  semi_liquid: {
+    label: "Semi-liquid",
+    color: "#2662d9",
+    description: "Investments convertible within days",
+  },
+  illiquid: {
+    label: "Illiquid",
+    color: "#eab308",
+    description: "Property, retirement, long-hold assets",
+  },
+  restricted: {
+    label: "Restricted",
+    color: "#8b5cf6",
+    description: "Escrow, deposits, earmarked",
+  },
+  unclassified: {
+    label: "Unclassified",
+    color: "#6b7280",
+    description: "Missing liquidity classification",
+  },
+};
+
+const DISPLAY_ORDER: LiquidityClass[] = [
+  "liquid",
+  "semi_liquid",
+  "illiquid",
+  "restricted",
+  "unclassified",
+];
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+
+export interface LiquidityTile {
+  liquidityClass: LiquidityClass;
+  label: string;
+  color: string;
+  value: number;
+  percent: number;
+  hasData: boolean;
+}
+
+/**
+ * Projects raw LiquidityData into the display-ready tile list used by the
+ * component. The "unclassified" bucket is only included when present in the
+ * data; the other four always render (as 0% if absent).
+ */
+export function buildLiquidityTiles(data: LiquidityData): LiquidityTile[] {
+  const byClass = new Map(data.classes.map((c) => [c.liquidityClass, c]));
+  const keys = DISPLAY_ORDER.filter((k) =>
+    k === "unclassified" ? byClass.has(k) : true
+  );
+  return keys.map((klass) => {
+    const meta = CLASS_META[klass];
+    const bucket = byClass.get(klass);
+    return {
+      liquidityClass: klass,
+      label: meta.label,
+      color: meta.color,
+      value: bucket?.value ?? 0,
+      percent: bucket?.percent ?? 0,
+      hasData: bucket != null,
+    };
+  });
+}
+
+interface LiquidityBreakdownProps {
+  data: LiquidityData;
+}
+
+export function LiquidityBreakdown({ data }: LiquidityBreakdownProps) {
+  const tiles = buildLiquidityTiles(data);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          Liquidity Breakdown
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div
+          className={`grid gap-3 ${
+            tiles.length === 5
+              ? "grid-cols-2 md:grid-cols-5"
+              : "grid-cols-2 md:grid-cols-4"
+          }`}
+        >
+          {tiles.map((tile) => (
+            <div
+              key={tile.liquidityClass}
+              data-testid={`liquidity-tile-${tile.liquidityClass}`}
+              className="rounded-lg border p-3"
+            >
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: tile.color }}
+                  aria-hidden
+                />
+                <span>{tile.label}</span>
+              </div>
+              <div className="mt-1 text-xl font-semibold tabular-nums tracking-tight">
+                {formatCurrency(tile.value)}
+              </div>
+              <div className="text-xs text-muted-foreground tabular-nums">
+                {tile.percent.toFixed(1)}%
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          className="flex h-2 w-full overflow-hidden rounded-full bg-muted"
+          role="img"
+          aria-label="Liquidity distribution"
+        >
+          {tiles.map((tile) => {
+            if (tile.percent <= 0) return null;
+            return (
+              <div
+                key={tile.liquidityClass}
+                data-testid={`liquidity-bar-${tile.liquidityClass}`}
+                style={{
+                  width: `${tile.percent}%`,
+                  backgroundColor: tile.color,
+                }}
+                title={`${tile.label}: ${tile.percent.toFixed(1)}%`}
+              />
+            );
+          })}
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Total: <span className="font-medium tabular-nums text-foreground">{formatCurrency(data.total)}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/dashboard/summary-drilldown-tabs.tsx
+++ b/app/components/dashboard/summary-drilldown-tabs.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 const drilldownTabs = [
   { value: "overview", label: "Overview", href: "/dashboard" },
   { value: "net-worth", label: "Net Worth", href: "/dashboard/net-worth" },
+  { value: "assets", label: "Assets", href: "/dashboard/assets" },
 ] as const;
 
 function getActiveDrilldown(pathname: string): string {

--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -46,6 +46,7 @@ export const accounts = pgTable("accounts", {
 	accountIdentifier: text("account_identifier"),
 	closedDate: date("closed_date"),
 	openedDate: date("opened_date"),
+	liquidityClass: text("liquidity_class"),
 }, (table) => [
 	foreignKey({
 			columns: [table.accountTypeId],
@@ -58,6 +59,7 @@ export const accountTypes = pgTable("account_types", {
 	accountTypeId: integer("account_type_id").primaryKey().generatedAlwaysAsIdentity({ name: "account_types_account_type_id_seq", startWith: 1, increment: 1, minValue: 1, maxValue: 2147483647, cache: 1 }),
 	accountType: text("account_type").notNull(),
 	accountTypeCategoryId: integer("account_type_category_id").notNull(),
+	liquidityClass: text("liquidity_class"),
 }, (table) => [
 	foreignKey({
 			columns: [table.accountTypeCategoryId],

--- a/app/lib/actions/account.ts
+++ b/app/lib/actions/account.ts
@@ -32,6 +32,8 @@ export async function createAccount(
     openedDate: (formData.get("openedDate") as string) || undefined,
     initialBalance:
       (formData.get("initialBalance") as string) || undefined,
+    liquidityClass:
+      (formData.get("liquidityClass") as string) || null,
   };
 
   const result = accountFormSchema.safeParse(raw);
@@ -51,6 +53,7 @@ export async function createAccount(
           accountTypeId: Number(data.accountTypeId),
           accountIdentifier: data.accountIdentifier || null,
           openedDate: data.openedDate || null,
+          liquidityClass: data.liquidityClass ?? null,
         })
         .returning({ accountId: accounts.accountId });
 
@@ -105,6 +108,8 @@ export async function updateAccount(
       (formData.get("accountIdentifier") as string) || undefined,
     openedDate: (formData.get("openedDate") as string) || undefined,
     closedDate: (formData.get("closedDate") as string) || undefined,
+    liquidityClass:
+      (formData.get("liquidityClass") as string) || null,
   };
 
   const result = accountFormSchema.safeParse(raw);
@@ -124,6 +129,7 @@ export async function updateAccount(
         accountIdentifier: data.accountIdentifier || null,
         openedDate: data.openedDate || null,
         closedDate: data.closedDate || null,
+        liquidityClass: data.liquidityClass ?? null,
       })
       .where(eq(accounts.accountId, accountId));
   } catch (error) {

--- a/app/lib/queries/accounts.ts
+++ b/app/lib/queries/accounts.ts
@@ -55,14 +55,19 @@ export async function getAccountBalances(): Promise<AccountBalanceRow[]> {
   }));
 }
 
-export async function getAccountTypes(): Promise<
-  { id: number; name: string }[]
-> {
+export interface AccountTypeOption {
+  id: number;
+  name: string;
+  liquidityClass: string | null;
+}
+
+export async function getAccountTypes(): Promise<AccountTypeOption[]> {
   const rows = await db
     .select({
       id: accountTypes.accountTypeId,
       type: accountTypes.accountType,
       category: accountTypeCategories.accountTypeCategory,
+      liquidityClass: accountTypes.liquidityClass,
     })
     .from(accountTypes)
     .innerJoin(
@@ -77,7 +82,11 @@ export async function getAccountTypes(): Promise<
       accountTypes.accountType
     );
 
-  return rows.map((r) => ({ id: r.id, name: `${r.type} (${r.category})` }));
+  return rows.map((r) => ({
+    id: r.id,
+    name: `${r.type} (${r.category})`,
+    liquidityClass: r.liquidityClass,
+  }));
 }
 
 export interface AccountRow {
@@ -89,6 +98,7 @@ export interface AccountRow {
   accountIdentifier: string | null;
   openedDate: string | null;
   closedDate: string | null;
+  liquidityClass: string | null;
 }
 
 export async function getAccountById(
@@ -104,6 +114,7 @@ export async function getAccountById(
       accountIdentifier: accounts.accountIdentifier,
       openedDate: accounts.openedDate,
       closedDate: accounts.closedDate,
+      liquidityClass: accounts.liquidityClass,
     })
     .from(accounts)
     .innerJoin(accountTypes, eq(accounts.accountTypeId, accountTypes.accountTypeId))

--- a/app/lib/queries/assets-drilldown.ts
+++ b/app/lib/queries/assets-drilldown.ts
@@ -1,0 +1,574 @@
+import { db } from "@/lib/db";
+import { sql } from "drizzle-orm";
+
+// Asset categories: Current Asset (1), Restricted Asset (2), Fixed Asset (3),
+// Investment (4). Liabilities (5, 6) are excluded. Restricted is kept in the
+// asset total to match getCurrentNetWorth().totalAssets, and surfaced as its
+// own bucket by the liquidity breakdown.
+const ASSET_CATEGORY_IDS = [1, 2, 3, 4] as const;
+
+export type LiquidityClass =
+  | "liquid"
+  | "semi_liquid"
+  | "illiquid"
+  | "restricted"
+  | "unclassified";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface AllocationAccountType {
+  accountTypeId: number;
+  accountTypeName: string;
+  value: number;
+  percentOfParent: number;
+  percentOfTotal: number;
+}
+
+export interface AllocationCategory {
+  categoryId: number;
+  categoryName: string;
+  value: number;
+  percentOfTotal: number;
+  children: AllocationAccountType[];
+}
+
+export interface AllocationData {
+  totalAssets: number;
+  asOf: string;
+  byCategory: AllocationCategory[];
+}
+
+export interface PerformanceAccount {
+  accountId: number;
+  accountName: string;
+  currentValue: number;
+  startValue: number;
+  change: number;
+  percentChange: number;
+  percentOfParent: number;
+  percentOfTotal: number;
+}
+
+export interface PerformanceAccountType {
+  accountTypeId: number;
+  accountTypeName: string;
+  currentValue: number;
+  startValue: number;
+  change: number;
+  percentChange: number;
+  percentOfParent: number;
+  percentOfTotal: number;
+  accounts: PerformanceAccount[];
+}
+
+export interface PerformanceCategory {
+  categoryId: number;
+  categoryName: string;
+  currentValue: number;
+  startValue: number;
+  change: number;
+  percentChange: number;
+  percentOfTotal: number;
+  accountTypes: PerformanceAccountType[];
+}
+
+export interface PerformanceData {
+  totalCurrentValue: number;
+  totalStartValue: number;
+  totalChange: number;
+  totalPercentChange: number;
+  categories: PerformanceCategory[];
+}
+
+export interface LiquidityBucket {
+  liquidityClass: LiquidityClass;
+  value: number;
+  percent: number;
+}
+
+export interface LiquidityData {
+  total: number;
+  asOf: string;
+  classes: LiquidityBucket[];
+}
+
+export interface AssetDecompositionPoint {
+  date: string;
+  categoryId: number;
+  categoryName: string;
+  accountTypeId: number;
+  accountTypeName: string;
+  accountId: number;
+  accountName: string;
+  liquidityClass: LiquidityClass;
+  cumulativeBalance: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const pct = (num: number, den: number) =>
+  den !== 0 ? round2((num / den) * 100) : 0;
+
+const normalizeLiquidity = (raw: string | null): LiquidityClass => {
+  if (
+    raw === "liquid" ||
+    raw === "semi_liquid" ||
+    raw === "illiquid" ||
+    raw === "restricted"
+  ) {
+    return raw;
+  }
+  return "unclassified";
+};
+
+// ── Queries ────────────────────────────────────────────────────────
+
+/**
+ * Snapshot of asset allocation as of `dateTo` (default: latest balance date
+ * per account). Returns nested structure suitable for feeding a treemap
+ * (category → account type).
+ */
+export async function getAssetAllocation(
+  dateTo?: string
+): Promise<AllocationData> {
+  const dateFilter = dateTo
+    ? sql`abh.balance_date = ${dateTo}::date`
+    : sql`abh.balance_date = (
+        SELECT MAX(balance_date) FROM account_balance_history
+        WHERE account_id = abh.account_id
+      )`;
+
+  const result = await db.execute(sql`
+    SELECT
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      MAX(abh.balance_date) AS as_of,
+      COALESCE(SUM(abh.cumulative_balance), 0) AS value
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    WHERE atc.account_type_category_id IN (1, 2, 3, 4)
+      AND ${dateFilter}
+    GROUP BY
+      atc.account_type_category_id, atc.account_type_category,
+      at.account_type_id, at.account_type
+    ORDER BY atc.account_type_category_id, at.account_type_id
+  `);
+
+  type Row = {
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    as_of: string | null;
+    value: string;
+  };
+
+  const rows = result.rows as Row[];
+
+  const catMap = new Map<
+    number,
+    {
+      categoryId: number;
+      categoryName: string;
+      value: number;
+      children: { id: number; name: string; value: number }[];
+    }
+  >();
+
+  let asOf: string | null = null;
+
+  for (const row of rows) {
+    const value = parseFloat(row.value) || 0;
+    if (row.as_of && (!asOf || row.as_of > asOf)) {
+      asOf = row.as_of;
+    }
+
+    let cat = catMap.get(row.category_id);
+    if (!cat) {
+      cat = {
+        categoryId: row.category_id,
+        categoryName: row.category_name,
+        value: 0,
+        children: [],
+      };
+      catMap.set(row.category_id, cat);
+    }
+    cat.value += value;
+    cat.children.push({
+      id: row.account_type_id,
+      name: row.account_type_name,
+      value,
+    });
+  }
+
+  const totalAssets = Array.from(catMap.values()).reduce(
+    (s, c) => s + c.value,
+    0
+  );
+
+  const byCategory: AllocationCategory[] = Array.from(catMap.values()).map(
+    (cat) => ({
+      categoryId: cat.categoryId,
+      categoryName: cat.categoryName,
+      value: cat.value,
+      percentOfTotal: pct(cat.value, totalAssets),
+      children: cat.children
+        .map((c) => ({
+          accountTypeId: c.id,
+          accountTypeName: c.name,
+          value: c.value,
+          percentOfParent: pct(c.value, cat.value),
+          percentOfTotal: pct(c.value, totalAssets),
+        }))
+        .sort((a, b) => b.value - a.value),
+    })
+  );
+
+  byCategory.sort((a, b) => b.value - a.value);
+
+  return {
+    totalAssets,
+    asOf: asOf ?? "",
+    byCategory,
+  };
+}
+
+/**
+ * Hierarchical period-over-period change (category → type → account) for
+ * asset categories only. "Return" is proxied by cumulative_balance delta;
+ * the schema does not track cost basis.
+ */
+export async function getAssetPerformance(
+  dateFrom: string,
+  dateTo?: string
+): Promise<PerformanceData> {
+  const endDate = dateTo ?? sql`CURRENT_DATE`;
+
+  const result = await db.execute(sql`
+    SELECT
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      a.account_id,
+      a.account_name,
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    WHERE atc.account_type_category_id IN (1, 2, 3, 4)
+      AND abh.balance_date IN (${dateFrom}::date, ${endDate}::date)
+    GROUP BY
+      atc.account_type_category_id, atc.account_type_category,
+      at.account_type_id, at.account_type,
+      a.account_id, a.account_name
+    ORDER BY atc.account_type_category_id, at.account_type_id, a.account_id
+  `);
+
+  type Row = {
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    account_id: number;
+    account_name: string;
+    start_balance: string;
+    end_balance: string;
+  };
+
+  const rows = result.rows as Row[];
+
+  const catMap = new Map<
+    number,
+    {
+      categoryId: number;
+      categoryName: string;
+      currentValue: number;
+      startValue: number;
+      types: Map<
+        number,
+        {
+          accountTypeId: number;
+          accountTypeName: string;
+          currentValue: number;
+          startValue: number;
+          accounts: {
+            accountId: number;
+            accountName: string;
+            currentValue: number;
+            startValue: number;
+          }[];
+        }
+      >;
+    }
+  >();
+
+  for (const row of rows) {
+    const startValue = parseFloat(row.start_balance) || 0;
+    const currentValue = parseFloat(row.end_balance) || 0;
+
+    let cat = catMap.get(row.category_id);
+    if (!cat) {
+      cat = {
+        categoryId: row.category_id,
+        categoryName: row.category_name,
+        currentValue: 0,
+        startValue: 0,
+        types: new Map(),
+      };
+      catMap.set(row.category_id, cat);
+    }
+    cat.currentValue += currentValue;
+    cat.startValue += startValue;
+
+    let type = cat.types.get(row.account_type_id);
+    if (!type) {
+      type = {
+        accountTypeId: row.account_type_id,
+        accountTypeName: row.account_type_name,
+        currentValue: 0,
+        startValue: 0,
+        accounts: [],
+      };
+      cat.types.set(row.account_type_id, type);
+    }
+    type.currentValue += currentValue;
+    type.startValue += startValue;
+    type.accounts.push({
+      accountId: row.account_id,
+      accountName: row.account_name,
+      currentValue,
+      startValue,
+    });
+  }
+
+  const totalCurrentValue = Array.from(catMap.values()).reduce(
+    (s, c) => s + c.currentValue,
+    0
+  );
+  const totalStartValue = Array.from(catMap.values()).reduce(
+    (s, c) => s + c.startValue,
+    0
+  );
+  const totalChange = totalCurrentValue - totalStartValue;
+
+  const categories: PerformanceCategory[] = Array.from(catMap.values())
+    .map((cat) => {
+      const catChange = cat.currentValue - cat.startValue;
+
+      const accountTypes: PerformanceAccountType[] = Array.from(
+        cat.types.values()
+      )
+        .map((t) => {
+          const typeChange = t.currentValue - t.startValue;
+
+          const accounts = t.accounts
+            .map((a) => {
+              const change = a.currentValue - a.startValue;
+              return {
+                accountId: a.accountId,
+                accountName: a.accountName,
+                currentValue: a.currentValue,
+                startValue: a.startValue,
+                change,
+                percentChange: pct(change, a.startValue),
+                percentOfParent: pct(a.currentValue, t.currentValue),
+                percentOfTotal: pct(a.currentValue, totalCurrentValue),
+              };
+            })
+            .sort((x, y) => y.currentValue - x.currentValue);
+
+          return {
+            accountTypeId: t.accountTypeId,
+            accountTypeName: t.accountTypeName,
+            currentValue: t.currentValue,
+            startValue: t.startValue,
+            change: typeChange,
+            percentChange: pct(typeChange, t.startValue),
+            percentOfParent: pct(t.currentValue, cat.currentValue),
+            percentOfTotal: pct(t.currentValue, totalCurrentValue),
+            accounts,
+          };
+        })
+        .sort((x, y) => y.currentValue - x.currentValue);
+
+      return {
+        categoryId: cat.categoryId,
+        categoryName: cat.categoryName,
+        currentValue: cat.currentValue,
+        startValue: cat.startValue,
+        change: catChange,
+        percentChange: pct(catChange, cat.startValue),
+        percentOfTotal: pct(cat.currentValue, totalCurrentValue),
+        accountTypes,
+      };
+    })
+    .sort((x, y) => y.currentValue - x.currentValue);
+
+  return {
+    totalCurrentValue,
+    totalStartValue,
+    totalChange,
+    totalPercentChange: pct(totalChange, totalStartValue),
+    categories,
+  };
+}
+
+/**
+ * Buckets current asset balances by effective liquidity class, using
+ * COALESCE(a.liquidity_class, at.liquidity_class) so per-account overrides
+ * take precedence over the type default. Accounts with no classification
+ * at either level roll up into the "unclassified" bucket.
+ */
+export async function getLiquidityBreakdown(
+  dateTo?: string
+): Promise<LiquidityData> {
+  const dateFilter = dateTo
+    ? sql`abh.balance_date = ${dateTo}::date`
+    : sql`abh.balance_date = (
+        SELECT MAX(balance_date) FROM account_balance_history
+        WHERE account_id = abh.account_id
+      )`;
+
+  const result = await db.execute(sql`
+    SELECT
+      COALESCE(a.liquidity_class, at.liquidity_class) AS liquidity_class,
+      MAX(abh.balance_date) AS as_of,
+      COALESCE(SUM(abh.cumulative_balance), 0) AS value
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    WHERE atc.account_type_category_id IN (1, 2, 3, 4)
+      AND ${dateFilter}
+    GROUP BY COALESCE(a.liquidity_class, at.liquidity_class)
+  `);
+
+  type Row = {
+    liquidity_class: string | null;
+    as_of: string | null;
+    value: string;
+  };
+
+  const rows = result.rows as Row[];
+
+  const bucketMap = new Map<LiquidityClass, number>();
+  let asOf: string | null = null;
+
+  for (const row of rows) {
+    const klass = normalizeLiquidity(row.liquidity_class);
+    const value = parseFloat(row.value) || 0;
+    bucketMap.set(klass, (bucketMap.get(klass) ?? 0) + value);
+    if (row.as_of && (!asOf || row.as_of > asOf)) {
+      asOf = row.as_of;
+    }
+  }
+
+  const total = Array.from(bucketMap.values()).reduce((s, v) => s + v, 0);
+
+  const order: LiquidityClass[] = [
+    "liquid",
+    "semi_liquid",
+    "illiquid",
+    "restricted",
+    "unclassified",
+  ];
+
+  const classes: LiquidityBucket[] = order
+    .filter((k) => bucketMap.has(k))
+    .map((k) => {
+      const value = bucketMap.get(k) ?? 0;
+      return {
+        liquidityClass: k,
+        value,
+        percent: pct(value, total),
+      };
+    });
+
+  return {
+    total,
+    asOf: asOf ?? "",
+    classes,
+  };
+}
+
+/**
+ * Daily cumulative balance per account, for the stacked time-series
+ * decomposition chart. Scoped to asset categories (1,2,3,4).
+ */
+export async function getAssetTrendDecomposition(
+  dateFrom?: string,
+  dateTo?: string
+): Promise<AssetDecompositionPoint[]> {
+  const conditions = [
+    sql`atc.account_type_category_id IN (1, 2, 3, 4)`,
+  ];
+
+  if (dateFrom) {
+    conditions.push(sql`abh.balance_date >= ${dateFrom}`);
+  }
+  if (dateTo) {
+    conditions.push(sql`abh.balance_date <= ${dateTo}`);
+  }
+
+  const whereClause = sql`WHERE ${sql.join(conditions, sql` AND `)}`;
+
+  const result = await db.execute(sql`
+    SELECT
+      abh.balance_date AS date,
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      a.account_id,
+      a.account_name,
+      COALESCE(a.liquidity_class, at.liquidity_class) AS liquidity_class,
+      abh.cumulative_balance
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    ${whereClause}
+    ORDER BY abh.balance_date ASC, atc.account_type_category_id, a.account_id
+  `);
+
+  type Row = {
+    date: string;
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    account_id: number;
+    account_name: string;
+    liquidity_class: string | null;
+    cumulative_balance: string;
+  };
+
+  return (result.rows as Row[]).map((row) => ({
+    date: row.date,
+    categoryId: row.category_id,
+    categoryName: row.category_name,
+    accountTypeId: row.account_type_id,
+    accountTypeName: row.account_type_name,
+    accountId: row.account_id,
+    accountName: row.account_name,
+    liquidityClass: normalizeLiquidity(row.liquidity_class),
+    cumulativeBalance: parseFloat(row.cumulative_balance) || 0,
+  }));
+}
+
+// Exported for consumers that want to iterate on a known-exhaustive list.
+export const ASSET_CATEGORY_ID_LIST = ASSET_CATEGORY_IDS;

--- a/app/lib/validations/account.ts
+++ b/app/lib/validations/account.ts
@@ -1,5 +1,14 @@
 import { z } from "zod/v4";
 
+export const LIQUIDITY_CLASSES = [
+  "liquid",
+  "semi_liquid",
+  "illiquid",
+  "restricted",
+] as const;
+
+export type LiquidityClass = (typeof LIQUIDITY_CLASSES)[number];
+
 export const accountFormSchema = z.object({
   accountName: z
     .string()
@@ -30,6 +39,7 @@ export const accountFormSchema = z.object({
       "Enter a valid dollar amount (e.g. 123.45 or -50.00)"
     )
     .optional(),
+  liquidityClass: z.enum(LIQUIDITY_CLASSES).nullable().optional(),
 });
 
 export type AccountFormData = z.infer<typeof accountFormSchema>;

--- a/app/tests/integration/actions/account.test.ts
+++ b/app/tests/integration/actions/account.test.ts
@@ -90,6 +90,47 @@ describe("createAccount", () => {
     expect(result.success).toBe(false);
     expect(result.errors).toHaveProperty("accountTypeId");
   });
+
+  it("persists liquidityClass when explicitly provided (override)", async () => {
+    const fd = makeFormData({
+      accountName: "Liq Override",
+      accountTypeId: "1",
+      liquidityClass: "illiquid",
+    });
+    const result = await createAccount(emptyState, fd);
+    expect(result.success).toBe(true);
+
+    const rows = await db
+      .select({
+        accountId: accounts.accountId,
+        liquidityClass: accounts.liquidityClass,
+      })
+      .from(accounts)
+      .where(eq(accounts.accountName, "Liq Override"));
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0].liquidityClass).toBe("illiquid");
+    createdAccountIds.push(...rows.map((r) => r.accountId));
+  });
+
+  it("stores null when liquidityClass is omitted (inherits from type)", async () => {
+    const fd = makeFormData({
+      accountName: "Liq Inherit",
+      accountTypeId: "1",
+    });
+    const result = await createAccount(emptyState, fd);
+    expect(result.success).toBe(true);
+
+    const rows = await db
+      .select({
+        accountId: accounts.accountId,
+        liquidityClass: accounts.liquidityClass,
+      })
+      .from(accounts)
+      .where(eq(accounts.accountName, "Liq Inherit"));
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0].liquidityClass).toBeNull();
+    createdAccountIds.push(...rows.map((r) => r.accountId));
+  });
 });
 
 // ─── updateAccount ────────────────────────────────────────────────────────────
@@ -145,6 +186,57 @@ describe("updateAccount", () => {
 
     expect(result.success).toBe(false);
     expect(result.errors).toHaveProperty("accountName");
+  });
+
+  it("round-trips liquidityClass (null → set → change → null)", async () => {
+    const readLiquidity = async () => {
+      const rows = await db
+        .select({ liquidityClass: accounts.liquidityClass })
+        .from(accounts)
+        .where(eq(accounts.accountId, testAccountId));
+      return rows[0]?.liquidityClass ?? null;
+    };
+
+    // Initial state: null (inherit)
+    expect(await readLiquidity()).toBeNull();
+
+    // Set to 'illiquid'
+    let result = await updateAccount(
+      emptyState,
+      makeFormData({
+        accountId: String(testAccountId),
+        accountName: "Update Test",
+        accountTypeId: "1",
+        liquidityClass: "illiquid",
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(await readLiquidity()).toBe("illiquid");
+
+    // Change to 'semi_liquid'
+    result = await updateAccount(
+      emptyState,
+      makeFormData({
+        accountId: String(testAccountId),
+        accountName: "Update Test",
+        accountTypeId: "1",
+        liquidityClass: "semi_liquid",
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(await readLiquidity()).toBe("semi_liquid");
+
+    // Clear back to null (omitted → coerced to null by action)
+    result = await updateAccount(
+      emptyState,
+      makeFormData({
+        accountId: String(testAccountId),
+        accountName: "Update Test",
+        accountTypeId: "1",
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(await readLiquidity()).toBeNull();
   });
 });
 

--- a/app/tests/integration/queries/assets-drilldown.test.ts
+++ b/app/tests/integration/queries/assets-drilldown.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { db } from "@/lib/db";
+import { accounts, accountBalanceHistory } from "@/drizzle/schema";
+import { eq, inArray } from "drizzle-orm";
+import {
+  getAssetAllocation,
+  getAssetPerformance,
+  getLiquidityBreakdown,
+  getAssetTrendDecomposition,
+} from "@/lib/queries/assets-drilldown";
+
+// Test dates — deliberately outside the mock-data seed range (2024-07-01 →
+// present), so queries scoped to these dates only return the rows this file
+// inserts.
+const SNAPSHOT_DATE = "2020-06-30";
+const PERF_START = "2020-01-01";
+const PERF_END = "2020-12-31";
+
+// Account-type IDs from init-db/seeds/finances-test-mock-data.sql, which are
+// stable across test runs.
+const TYPE_CASH = 1; // Current Asset, liquid
+const TYPE_CHECKING = 2; // Current Asset, liquid
+const TYPE_ESCROW = 6; // Restricted Asset, restricted
+const TYPE_REAL_ESTATE = 10; // Fixed Asset, illiquid
+const TYPE_STOCK = 12; // Investment, semi_liquid
+const TYPE_CREDIT_CARD = 15; // Current Liability (should be excluded)
+
+const createdAccountIds: number[] = [];
+
+async function createAccount(
+  name: string,
+  accountTypeId: number,
+  liquidityClass: string | null = null
+): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({ accountName: name, accountTypeId, liquidityClass })
+    .returning({ accountId: accounts.accountId });
+  createdAccountIds.push(row.accountId);
+  return row.accountId;
+}
+
+async function insertBalance(
+  accountId: number,
+  balanceDate: string,
+  cumulativeBalance: string
+) {
+  await db.insert(accountBalanceHistory).values({
+    accountId,
+    balanceDate,
+    dailyBalance: "0.00",
+    cumulativeBalance,
+  });
+}
+
+afterEach(async () => {
+  if (createdAccountIds.length > 0) {
+    await db
+      .delete(accountBalanceHistory)
+      .where(inArray(accountBalanceHistory.accountId, createdAccountIds));
+    await db.delete(accounts).where(inArray(accounts.accountId, createdAccountIds));
+    createdAccountIds.length = 0;
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getAssetAllocation
+// ────────────────────────────────────────────────────────────────────
+
+describe("getAssetAllocation", () => {
+  it("aggregates asset balances by category and account type", async () => {
+    const cashId = await createAccount("Alloc Cash", TYPE_CASH);
+    const checkingId = await createAccount("Alloc Checking", TYPE_CHECKING);
+    const escrowId = await createAccount("Alloc Escrow", TYPE_ESCROW);
+    const stockId = await createAccount("Alloc Stock", TYPE_STOCK);
+    const realEstateId = await createAccount("Alloc Real Estate", TYPE_REAL_ESTATE);
+    const cardId = await createAccount("Alloc Card", TYPE_CREDIT_CARD);
+
+    await insertBalance(cashId, SNAPSHOT_DATE, "1000.00");
+    await insertBalance(checkingId, SNAPSHOT_DATE, "2000.00");
+    await insertBalance(escrowId, SNAPSHOT_DATE, "500.00");
+    await insertBalance(stockId, SNAPSHOT_DATE, "5000.00");
+    await insertBalance(realEstateId, SNAPSHOT_DATE, "200000.00");
+    await insertBalance(cardId, SNAPSHOT_DATE, "-300.00");
+
+    const result = await getAssetAllocation(SNAPSHOT_DATE);
+
+    // Total excludes the liability (card).
+    expect(result.totalAssets).toBe(1000 + 2000 + 500 + 5000 + 200000);
+
+    // Only asset categories (1..4) are present.
+    for (const cat of result.byCategory) {
+      expect([1, 2, 3, 4]).toContain(cat.categoryId);
+    }
+
+    // Each category's children values sum to the parent value.
+    for (const cat of result.byCategory) {
+      const childSum = cat.children.reduce((s, c) => s + c.value, 0);
+      expect(childSum).toBeCloseTo(cat.value, 2);
+    }
+
+    // Percents sum to 100 (allowing rounding slack).
+    const catPercentSum = result.byCategory.reduce(
+      (s, c) => s + c.percentOfTotal,
+      0
+    );
+    expect(catPercentSum).toBeGreaterThan(99.5);
+    expect(catPercentSum).toBeLessThan(100.5);
+
+    // Cat 1 (Current Asset) should equal cash + checking.
+    const currentAsset = result.byCategory.find((c) => c.categoryId === 1);
+    expect(currentAsset?.value).toBe(3000);
+
+    // Cat 3 (Fixed Asset) should include real estate.
+    const fixedAsset = result.byCategory.find((c) => c.categoryId === 3);
+    expect(fixedAsset?.value).toBe(200000);
+  });
+
+  it("excludes liability categories entirely", async () => {
+    const cashId = await createAccount("Exclude Cash", TYPE_CASH);
+    const cardId = await createAccount("Exclude Card", TYPE_CREDIT_CARD);
+    await insertBalance(cashId, SNAPSHOT_DATE, "100.00");
+    await insertBalance(cardId, SNAPSHOT_DATE, "-100.00");
+
+    const result = await getAssetAllocation(SNAPSHOT_DATE);
+
+    // No category 5 or 6 appears.
+    for (const cat of result.byCategory) {
+      expect(cat.categoryId).not.toBe(5);
+      expect(cat.categoryId).not.toBe(6);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getAssetPerformance
+// ────────────────────────────────────────────────────────────────────
+
+describe("getAssetPerformance", () => {
+  it("returns hierarchical change with category = sum(type) = sum(account)", async () => {
+    const cashId = await createAccount("Perf Cash", TYPE_CASH);
+    const stockId = await createAccount("Perf Stock", TYPE_STOCK);
+
+    await insertBalance(cashId, PERF_START, "1000.00");
+    await insertBalance(cashId, PERF_END, "1500.00");
+    await insertBalance(stockId, PERF_START, "10000.00");
+    await insertBalance(stockId, PERF_END, "12000.00");
+
+    const result = await getAssetPerformance(PERF_START, PERF_END);
+
+    expect(result.totalCurrentValue).toBe(1500 + 12000);
+    expect(result.totalStartValue).toBe(1000 + 10000);
+    expect(result.totalChange).toBe(
+      result.totalCurrentValue - result.totalStartValue
+    );
+
+    for (const cat of result.categories) {
+      expect(cat.change).toBeCloseTo(cat.currentValue - cat.startValue, 2);
+      const typeSum = cat.accountTypes.reduce((s, t) => s + t.currentValue, 0);
+      expect(typeSum).toBeCloseTo(cat.currentValue, 2);
+      const typeStartSum = cat.accountTypes.reduce(
+        (s, t) => s + t.startValue,
+        0
+      );
+      expect(typeStartSum).toBeCloseTo(cat.startValue, 2);
+
+      for (const type of cat.accountTypes) {
+        const acctSum = type.accounts.reduce((s, a) => s + a.currentValue, 0);
+        expect(acctSum).toBeCloseTo(type.currentValue, 2);
+        const acctStartSum = type.accounts.reduce(
+          (s, a) => s + a.startValue,
+          0
+        );
+        expect(acctStartSum).toBeCloseTo(type.startValue, 2);
+      }
+    }
+  });
+
+  it("scopes to asset categories only", async () => {
+    const cashId = await createAccount("PerfScope Cash", TYPE_CASH);
+    const cardId = await createAccount("PerfScope Card", TYPE_CREDIT_CARD);
+
+    await insertBalance(cashId, PERF_START, "100.00");
+    await insertBalance(cashId, PERF_END, "200.00");
+    await insertBalance(cardId, PERF_START, "-50.00");
+    await insertBalance(cardId, PERF_END, "-25.00");
+
+    const result = await getAssetPerformance(PERF_START, PERF_END);
+
+    for (const cat of result.categories) {
+      expect([1, 2, 3, 4]).toContain(cat.categoryId);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getLiquidityBreakdown
+// ────────────────────────────────────────────────────────────────────
+
+describe("getLiquidityBreakdown", () => {
+  it("buckets assets by effective liquidity class (type default)", async () => {
+    const cashId = await createAccount("Liq Cash", TYPE_CASH); // liquid
+    const stockId = await createAccount("Liq Stock", TYPE_STOCK); // semi_liquid
+    const realEstateId = await createAccount("Liq Real Estate", TYPE_REAL_ESTATE); // illiquid
+    const escrowId = await createAccount("Liq Escrow", TYPE_ESCROW); // restricted
+
+    await insertBalance(cashId, SNAPSHOT_DATE, "1000.00");
+    await insertBalance(stockId, SNAPSHOT_DATE, "5000.00");
+    await insertBalance(realEstateId, SNAPSHOT_DATE, "100000.00");
+    await insertBalance(escrowId, SNAPSHOT_DATE, "500.00");
+
+    const result = await getLiquidityBreakdown(SNAPSHOT_DATE);
+
+    expect(result.total).toBe(1000 + 5000 + 100000 + 500);
+
+    const sumOfBuckets = result.classes.reduce((s, c) => s + c.value, 0);
+    expect(sumOfBuckets).toBeCloseTo(result.total, 2);
+
+    const byClass = (k: string) =>
+      result.classes.find((c) => c.liquidityClass === k)?.value ?? 0;
+
+    expect(byClass("liquid")).toBe(1000);
+    expect(byClass("semi_liquid")).toBe(5000);
+    expect(byClass("illiquid")).toBe(100000);
+    expect(byClass("restricted")).toBe(500);
+  });
+
+  it("respects per-account liquidity override (COALESCE)", async () => {
+    // Real-estate account (type default = illiquid) overridden to liquid.
+    const overriddenId = await createAccount(
+      "Liq Override",
+      TYPE_REAL_ESTATE,
+      "liquid"
+    );
+    await insertBalance(overriddenId, SNAPSHOT_DATE, "75000.00");
+
+    const result = await getLiquidityBreakdown(SNAPSHOT_DATE);
+
+    const liquidTotal =
+      result.classes.find((c) => c.liquidityClass === "liquid")?.value ?? 0;
+    const illiquidTotal =
+      result.classes.find((c) => c.liquidityClass === "illiquid")?.value ?? 0;
+
+    // Overridden real-estate counts against liquid, NOT illiquid.
+    expect(liquidTotal).toBeGreaterThanOrEqual(75000);
+    expect(illiquidTotal).toBeLessThan(75000);
+  });
+
+  it("bucket percents sum to 100", async () => {
+    const cashId = await createAccount("LiqPct Cash", TYPE_CASH);
+    const stockId = await createAccount("LiqPct Stock", TYPE_STOCK);
+    await insertBalance(cashId, SNAPSHOT_DATE, "2500.00");
+    await insertBalance(stockId, SNAPSHOT_DATE, "7500.00");
+
+    const result = await getLiquidityBreakdown(SNAPSHOT_DATE);
+
+    const pctSum = result.classes.reduce((s, c) => s + c.percent, 0);
+    expect(pctSum).toBeGreaterThan(99.5);
+    expect(pctSum).toBeLessThan(100.5);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getAssetTrendDecomposition
+// ────────────────────────────────────────────────────────────────────
+
+describe("getAssetTrendDecomposition", () => {
+  it("returns rows only for asset categories within the date range", async () => {
+    const cashId = await createAccount("Trend Cash", TYPE_CASH);
+    const stockId = await createAccount("Trend Stock", TYPE_STOCK);
+    const cardId = await createAccount("Trend Card", TYPE_CREDIT_CARD);
+
+    await insertBalance(cashId, PERF_START, "100.00");
+    await insertBalance(cashId, PERF_END, "200.00");
+    await insertBalance(stockId, PERF_START, "1000.00");
+    await insertBalance(stockId, PERF_END, "2000.00");
+    await insertBalance(cardId, PERF_START, "-10.00");
+    await insertBalance(cardId, PERF_END, "-5.00");
+
+    const rows = await getAssetTrendDecomposition(PERF_START, PERF_END);
+
+    // No liability rows.
+    for (const r of rows) {
+      expect([1, 2, 3, 4]).toContain(r.categoryId);
+      expect(r.date >= PERF_START && r.date <= PERF_END).toBe(true);
+    }
+
+    // Our four test balance rows are all present.
+    const myIds = new Set([cashId, stockId]);
+    const mine = rows.filter((r) => myIds.has(r.accountId));
+    expect(mine).toHaveLength(4);
+  });
+
+  it("respects dateFrom/dateTo bounds", async () => {
+    const cashId = await createAccount("Bounds Cash", TYPE_CASH);
+    await insertBalance(cashId, "2019-01-01", "50.00");
+    await insertBalance(cashId, "2020-06-30", "100.00");
+    await insertBalance(cashId, "2021-12-31", "150.00");
+
+    const rows = await getAssetTrendDecomposition("2020-01-01", "2020-12-31");
+    const mine = rows.filter((r) => r.accountId === cashId);
+
+    expect(mine).toHaveLength(1);
+    expect(mine[0].date).toBe("2020-06-30");
+  });
+});

--- a/app/tests/integration/vitest-setup.ts
+++ b/app/tests/integration/vitest-setup.ts
@@ -26,6 +26,19 @@ vi.mock("next/navigation", () => ({
 // CASCADE would wipe seeded accounts/transactions/account_balance_history
 // that other tests rely on.
 beforeAll(async () => {
+  // Ensure liquidity_class column exists before any upsert references it.
+  // Safe for test DBs that predate the liquidity_class migration.
+  await db.execute(sql`
+    ALTER TABLE account_types
+      ADD COLUMN IF NOT EXISTS liquidity_class text
+      CHECK (liquidity_class IN ('liquid','semi_liquid','illiquid','restricted'))
+  `);
+  await db.execute(sql`
+    ALTER TABLE accounts
+      ADD COLUMN IF NOT EXISTS liquidity_class text
+      CHECK (liquidity_class IN ('liquid','semi_liquid','illiquid','restricted'))
+  `);
+
   await db.execute(sql`
     INSERT INTO account_type_categories (account_type_category_id, account_type_category)
     OVERRIDING SYSTEM VALUE VALUES
@@ -40,12 +53,13 @@ beforeAll(async () => {
   `);
 
   await db.execute(sql`
-    INSERT INTO account_types (account_type_id, account_type, account_type_category_id)
+    INSERT INTO account_types (account_type_id, account_type, account_type_category_id, liquidity_class)
     OVERRIDING SYSTEM VALUE VALUES
-      (1, 'Cash & Cash Equivalent', 1)
+      (1, 'Cash & Cash Equivalent', 1, 'liquid')
     ON CONFLICT (account_type_id) DO UPDATE
       SET account_type = EXCLUDED.account_type,
-          account_type_category_id = EXCLUDED.account_type_category_id
+          account_type_category_id = EXCLUDED.account_type_category_id,
+          liquidity_class = EXCLUDED.liquidity_class
   `);
 
   await db.execute(sql`

--- a/app/tests/unit/components/asset-performance-table.test.ts
+++ b/app/tests/unit/components/asset-performance-table.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  signedCurrency,
+  signedPercent,
+  changeColor,
+} from "@/components/dashboard/asset-performance-table";
+
+describe("signedCurrency", () => {
+  it("prefixes positive values with '+'", () => {
+    expect(signedCurrency(1234.56)).toBe("+$1,234.56");
+  });
+
+  it("prefixes negative values with '-' (single dash, not double)", () => {
+    // Math.abs() is applied first, so we never get "--$X"
+    expect(signedCurrency(-1234.56)).toBe("-$1,234.56");
+  });
+
+  it("returns zero without a sign", () => {
+    expect(signedCurrency(0)).toBe("$0.00");
+  });
+});
+
+describe("signedPercent", () => {
+  it("prefixes positive values with '+'", () => {
+    expect(signedPercent(12.34)).toBe("+12.34%");
+  });
+
+  it("prefixes negative values with '-'", () => {
+    expect(signedPercent(-12.34)).toBe("-12.34%");
+  });
+
+  it("returns zero with two decimals and no sign", () => {
+    expect(signedPercent(0)).toBe("0.00%");
+  });
+
+  it("rounds to two decimal places", () => {
+    expect(signedPercent(12.3456)).toBe("+12.35%");
+  });
+});
+
+describe("changeColor", () => {
+  it("returns green for positive values", () => {
+    expect(changeColor(1)).toContain("green");
+  });
+
+  it("returns red for negative values", () => {
+    expect(changeColor(-1)).toContain("red");
+  });
+
+  it("returns an empty class for zero", () => {
+    expect(changeColor(0)).toBe("");
+  });
+});

--- a/app/tests/unit/components/liquidity-breakdown.test.ts
+++ b/app/tests/unit/components/liquidity-breakdown.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { buildLiquidityTiles } from "@/components/dashboard/liquidity-breakdown";
+import type { LiquidityData } from "@/lib/queries/assets-drilldown";
+
+describe("buildLiquidityTiles", () => {
+  it("returns the four standard tiles when no unclassified data is present", () => {
+    const data: LiquidityData = {
+      total: 100_000,
+      asOf: "2026-04-19",
+      classes: [
+        { liquidityClass: "liquid", value: 25_000, percent: 25 },
+        { liquidityClass: "semi_liquid", value: 25_000, percent: 25 },
+        { liquidityClass: "illiquid", value: 40_000, percent: 40 },
+        { liquidityClass: "restricted", value: 10_000, percent: 10 },
+      ],
+    };
+
+    const tiles = buildLiquidityTiles(data);
+
+    expect(tiles.map((t) => t.liquidityClass)).toEqual([
+      "liquid",
+      "semi_liquid",
+      "illiquid",
+      "restricted",
+    ]);
+    expect(tiles.every((t) => t.hasData)).toBe(true);
+  });
+
+  it("includes the unclassified tile when present in the data", () => {
+    const data: LiquidityData = {
+      total: 1_100,
+      asOf: "2026-04-19",
+      classes: [
+        { liquidityClass: "liquid", value: 1_000, percent: 90.91 },
+        { liquidityClass: "unclassified", value: 100, percent: 9.09 },
+      ],
+    };
+
+    const tiles = buildLiquidityTiles(data);
+    const classes = tiles.map((t) => t.liquidityClass);
+    expect(classes).toContain("unclassified");
+    expect(classes).toHaveLength(5);
+  });
+
+  it("renders 0% / $0 for missing standard classes", () => {
+    const data: LiquidityData = {
+      total: 500,
+      asOf: "2026-04-19",
+      classes: [{ liquidityClass: "liquid", value: 500, percent: 100 }],
+    };
+
+    const tiles = buildLiquidityTiles(data);
+    const missing = tiles.filter(
+      (t) => t.liquidityClass !== "liquid" && !t.hasData
+    );
+    for (const t of missing) {
+      expect(t.value).toBe(0);
+      expect(t.percent).toBe(0);
+    }
+  });
+
+  it("percents sum to approximately 100 (within rounding slack)", () => {
+    const data: LiquidityData = {
+      total: 100_000,
+      asOf: "2026-04-19",
+      classes: [
+        { liquidityClass: "liquid", value: 33_333, percent: 33.33 },
+        { liquidityClass: "semi_liquid", value: 33_333, percent: 33.33 },
+        { liquidityClass: "illiquid", value: 33_334, percent: 33.34 },
+      ],
+    };
+
+    const tiles = buildLiquidityTiles(data);
+    const pctSum = tiles.reduce((s, t) => s + t.percent, 0);
+    expect(pctSum).toBeGreaterThan(99.5);
+    expect(pctSum).toBeLessThan(100.5);
+  });
+
+  it("handles an empty data set without throwing", () => {
+    const data: LiquidityData = {
+      total: 0,
+      asOf: "",
+      classes: [],
+    };
+
+    const tiles = buildLiquidityTiles(data);
+    expect(tiles).toHaveLength(4); // unclassified excluded when absent
+    for (const t of tiles) {
+      expect(t.value).toBe(0);
+      expect(t.percent).toBe(0);
+      expect(t.hasData).toBe(false);
+    }
+  });
+});

--- a/app/tests/unit/validations/account.test.ts
+++ b/app/tests/unit/validations/account.test.ts
@@ -116,4 +116,53 @@ describe("accountFormSchema", () => {
       expect(result.data.openedDate).toBeUndefined();
     }
   });
+
+  it("accepts each valid liquidity class", () => {
+    for (const klass of [
+      "liquid",
+      "semi_liquid",
+      "illiquid",
+      "restricted",
+    ] as const) {
+      const result = accountFormSchema.safeParse({
+        accountName: "Test",
+        accountTypeId: "1",
+        liquidityClass: klass,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("accepts null liquidityClass (inherit from type)", () => {
+    const result = accountFormSchema.safeParse({
+      accountName: "Test",
+      accountTypeId: "1",
+      liquidityClass: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts missing liquidityClass (undefined)", () => {
+    const result = accountFormSchema.safeParse({
+      accountName: "Test",
+      accountTypeId: "1",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.liquidityClass).toBeUndefined();
+    }
+  });
+
+  it("rejects arbitrary liquidityClass strings", () => {
+    const result = accountFormSchema.safeParse({
+      accountName: "Test",
+      accountTypeId: "1",
+      liquidityClass: "very_liquid",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const fields = result.error.issues.map((i) => String(i.path[0]));
+      expect(fields).toContain("liquidityClass");
+    }
+  });
 });

--- a/init-db/schema.sql
+++ b/init-db/schema.sql
@@ -27,7 +27,10 @@ ALTER TABLE public.account_type_categories ALTER COLUMN account_type_category_id
 CREATE TABLE IF NOT EXISTS public.account_types (
     account_type_id integer NOT NULL,
     account_type text NOT NULL,
-    account_type_category_id integer NOT NULL
+    account_type_category_id integer NOT NULL,
+    liquidity_class text,
+    CONSTRAINT account_types_liquidity_class_check
+        CHECK (liquidity_class IN ('liquid','semi_liquid','illiquid','restricted'))
 );
 
 ALTER TABLE public.account_types ALTER COLUMN account_type_id ADD GENERATED ALWAYS AS IDENTITY (
@@ -77,7 +80,10 @@ CREATE TABLE IF NOT EXISTS public.accounts (
     account_type_id integer NOT NULL,
     account_identifier text,
     closed_date date,
-    opened_date date
+    opened_date date,
+    liquidity_class text,
+    CONSTRAINT accounts_liquidity_class_check
+        CHECK (liquidity_class IN ('liquid','semi_liquid','illiquid','restricted'))
 );
 
 COMMENT ON TABLE public.accounts IS 'All accounts that contribute transactions.';

--- a/init-db/seeds/finances-test-mock-data.sql
+++ b/init-db/seeds/finances-test-mock-data.sql
@@ -15,28 +15,29 @@
 
 -- --------------------------------------------
 -- 1. account_types (19 rows)
+--    liquidity_class is per-type default; liabilities intentionally NULL.
 -- --------------------------------------------
-INSERT INTO account_types (account_type_id, account_type, account_type_category_id)
+INSERT INTO account_types (account_type_id, account_type, account_type_category_id, liquidity_class)
 OVERRIDING SYSTEM VALUE VALUES
-    (1,  'Cash & Cash Equivalent',      1),
-    (2,  'Checking Account',            1),
-    (3,  'Savings Account',             1),
-    (4,  'Accounts Receivable',         1),
-    (5,  'Short-term Investment',       1),
-    (6,  'Escrow Account',              2),
-    (7,  'Security Deposit',            2),
-    (8,  'Earmarked',                   2),
-    (9,  'Certificate of Deposit',      4),
-    (10, 'Real Estate',                 3),
-    (11, 'Vehicle',                     3),
-    (12, 'Stock, Bond, or Mutual Fund', 4),
-    (13, 'Retirement Account',          4),
-    (14, 'Cryptocurrency',              4),
-    (15, 'Credit Card',                 5),
-    (16, 'Short-term Loan',             6),
-    (17, 'Mortgage',                    6),
-    (18, 'Student Loan',                6),
-    (19, 'Auto Loan',                   6)
+    (1,  'Cash & Cash Equivalent',      1, 'liquid'),
+    (2,  'Checking Account',            1, 'liquid'),
+    (3,  'Savings Account',             1, 'liquid'),
+    (4,  'Accounts Receivable',         1, 'liquid'),
+    (5,  'Short-term Investment',       1, 'semi_liquid'),
+    (6,  'Escrow Account',              2, 'restricted'),
+    (7,  'Security Deposit',            2, 'restricted'),
+    (8,  'Earmarked',                   2, 'restricted'),
+    (9,  'Certificate of Deposit',      4, 'semi_liquid'),
+    (10, 'Real Estate',                 3, 'illiquid'),
+    (11, 'Vehicle',                     3, 'illiquid'),
+    (12, 'Stock, Bond, or Mutual Fund', 4, 'semi_liquid'),
+    (13, 'Retirement Account',          4, 'illiquid'),
+    (14, 'Cryptocurrency',              4, 'semi_liquid'),
+    (15, 'Credit Card',                 5, NULL),
+    (16, 'Short-term Loan',             6, NULL),
+    (17, 'Mortgage',                    6, NULL),
+    (18, 'Student Loan',                6, NULL),
+    (19, 'Auto Loan',                   6, NULL)
 ON CONFLICT (account_type_id) DO NOTHING;
 
 -- --------------------------------------------

--- a/init-db/seeds/shared-lookups.sql
+++ b/init-db/seeds/shared-lookups.sql
@@ -51,3 +51,32 @@ SELECT setval(
     pg_get_serial_sequence('transaction_types', 'transaction_type_id'),
     GREATEST((SELECT MAX(transaction_type_id) FROM transaction_types), 1)
 );
+
+-- ==============================================
+-- account_types.liquidity_class defaults
+--
+-- This file does not seed account_types rows themselves (those are
+-- user-created in Finances and fixture-seeded in Finances_Test), but
+-- when rows with these known account_type names exist, fill in the
+-- liquidity_class default. Idempotent: WHERE liquidity_class IS NULL
+-- so user overrides are never clobbered. Liabilities intentionally
+-- remain NULL.
+-- ==============================================
+
+UPDATE account_types SET liquidity_class = 'liquid'
+    WHERE liquidity_class IS NULL AND account_type IN (
+        'Cash & Cash Equivalent','Accounts Receivable',
+        'Checking Account','Savings Account');
+
+UPDATE account_types SET liquidity_class = 'semi_liquid'
+    WHERE liquidity_class IS NULL AND account_type IN (
+        'Short-term Investment','Stock, Bond, or Mutual Fund',
+        'Cryptocurrency','Certificate of Deposit');
+
+UPDATE account_types SET liquidity_class = 'illiquid'
+    WHERE liquidity_class IS NULL AND account_type IN (
+        'Real Estate','Vehicle','Retirement Account');
+
+UPDATE account_types SET liquidity_class = 'restricted'
+    WHERE liquidity_class IS NULL AND account_type IN (
+        'Escrow Account','Security Deposit','Earmarked');


### PR DESCRIPTION
Closes #102.

## Summary

Adds a new drill-down page at `/dashboard/assets` — triggered from the Total Assets chart and the "Assets per $ of Debt" gauge on the Summary tab, or via a new **Assets** tab in `SummaryDrilldownTabs` — surfacing four views of the asset portfolio:

- **Allocation** — Recharts treemap keyed by category → account type.
- **Performance** — hierarchical category → type → account table with period-over-period delta (proxy for return, using `cumulative_balance` — no cost-basis schema in v1), % change, and % of total. Expand/collapse with scroll-preservation, mirroring `net-worth-drivers-table.tsx`.
- **Liquidity breakdown** — new classification (`liquid` / `semi_liquid` / `illiquid` / `restricted`) rendered as KPI tiles + a stacked horizontal bar. An `unclassified` tile only appears when data contains such rows.
- **Trend** — stacked Recharts `AreaChart` of daily asset balance by category.

## Schema

- New nullable `liquidity_class text CHECK (...)` column on both `account_types` (default per type) and `accounts` (per-account override). Queries resolve via `COALESCE(a.liquidity_class, at.liquidity_class)`.
- Seeded defaults for all 14 asset types in `shared-lookups.sql`; liabilities remain `NULL` intentionally.
- `init-db/schema.sql` updated to reflect the columns so fresh installs pick them up automatically.
- `vitest-setup.ts` guarded with `ADD COLUMN IF NOT EXISTS` so already-running test DBs gain the column without a manual rebuild.

## UI changes

- **Account create / edit form** — new Liquidity dropdown with an "Inherit from type" default; selecting a type shows that type's default liquidity as helper text. Persists `null` when inheriting.
- **Summary tab** — Total Assets chart is now a link; "Assets per $ of Debt" gauge is wrapped in a hover-highlighted `<Link>`; `SummaryDrilldownTabs` gains the Assets tab.

## New modules

- `app/lib/queries/assets-drilldown.ts` — `getAssetAllocation`, `getAssetPerformance`, `getLiquidityBreakdown`, `getAssetTrendDecomposition` (mirrors the net-worth drill-down pattern).
- `app/components/charts/asset-allocation-chart.tsx`, `app/components/charts/assets-timeseries-chart.tsx`.
- `app/components/dashboard/asset-performance-table.tsx`, `app/components/dashboard/liquidity-breakdown.tsx`.

## Tests

- **Integration** (+12): 9 new cases in `tests/integration/queries/assets-drilldown.test.ts` covering totals, hierarchy sums, percent reconciliation, date-range bounds, and the per-account liquidity override path; +3 cases in `tests/integration/actions/account.test.ts` covering `liquidity_class` create / round-trip / null.
- **Unit** (+20): `tests/unit/components/asset-performance-table.test.ts` (signed currency/percent/color helpers), `tests/unit/components/liquidity-breakdown.test.ts` (`buildLiquidityTiles` projector), and +5 cases in `tests/unit/validations/account.test.ts` for the new Zod enum.
- Full suite green: **74 unit + 57 integration = 131 tests pass.** `tsc --noEmit` clean.

## Test plan

- [x] On `/dashboard`, clicking the Total Assets chart routes to `/dashboard/assets`.
- [x] On `/dashboard`, clicking the "Assets per $ of Debt" gauge routes to `/dashboard/assets`.
- [x] `SummaryDrilldownTabs` shows Overview / Net Worth / Assets and routes correctly from each.
- [x] `/dashboard/assets` headline total equals `getCurrentNetWorth().totalAssets` for the same `dateTo`.
- [x] Treemap tile areas look proportional; percents reconcile to 100%.
- [x] Performance table: expand/collapse preserves scroll; category sum = type sum = account sum.
- [x] Liquidity tiles sum to headline; a per-account override is honored over the type default.
- [x] Trend stacked areas sum to the Summary-tab daily Total Assets line.
- [x] Date-range filter round-trips through the URL.
- [x] Account form: selecting a type shows its default liquidity; user can override or inherit; null round-trips through create → edit.
- [x] `npm run test` passes.