### PR TITLE
Issue #105 - Related Account column on Transactions table

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,14 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
 
-### 2026-04-19 — v0.1.2 (in progress)
+### 2026-05-01 — v0.1.2 (in progress)
+
+**Related Account column on the Transactions table (Issue #105)**
+- Added a "Related Account" column to the Transactions list at `/dashboard/transactions`, rendering `related_account_name` from `v_transactions_full`. Most rows are blank — the field is only populated for transfers between accounts.
+- Column is sortable (registered in `SORTABLE_COLUMNS` in `lib/queries/transactions.ts` as `relatedAccountName`) and respects the existing localStorage-backed column visibility toggle. Existing users with a saved column preference will need to enable it once via the Columns popover; new users see it by default.
+- No schema, migration, query, validation, or form changes — the data was already exposed in the view, the Drizzle schema, and the inline edit row; only the table UI was missing the column.
+
+### 2026-04-19
 
 **Assets drilldown page + liquidity classification (Issue #102)**
 - New page at `/dashboard/assets` surfaces asset allocation (treemap by category → account type), period-over-period performance (hierarchical category → type → account table), liquidity breakdown, and a stacked time-series decomposition. Triggered from the Total Assets chart and the Assets-per-$-of-Debt gauge on the Summary tab, or via a new Assets tab in `SummaryDrilldownTabs`.

--- a/app/app/(app)/dashboard/transactions/page.tsx
+++ b/app/app/(app)/dashboard/transactions/page.tsx
@@ -44,7 +44,7 @@ function parseSearchParams(
 
   const VALID_SORT_COLUMNS: SortableColumn[] = [
     "transactionDate", "transactionDescription", "amount",
-    "accountName", "transactionType", "transactionCategory",
+    "accountName", "relatedAccountName", "transactionType", "transactionCategory",
   ];
   const VALID_SORT_DIRS: SortDirection[] = ["asc", "desc"];
 

--- a/app/components/transactions/transaction-list.tsx
+++ b/app/components/transactions/transaction-list.tsx
@@ -58,6 +58,7 @@ export type ColumnKey =
   | "description"
   | "amount"
   | "account"
+  | "relatedAccount"
   | "type"
   | "category";
 
@@ -118,6 +119,12 @@ const COLUMNS: ColumnDef[] = [
     label: "Account",
     sortColumn: "accountName",
     render: (txn) => txn.accountName,
+  },
+  {
+    key: "relatedAccount",
+    label: "Related Account",
+    sortColumn: "relatedAccountName",
+    render: (txn) => txn.relatedAccountName,
   },
   {
     key: "type",

--- a/app/lib/queries/transactions.ts
+++ b/app/lib/queries/transactions.ts
@@ -7,6 +7,7 @@ export type SortableColumn =
   | "transactionDescription"
   | "amount"
   | "accountName"
+  | "relatedAccountName"
   | "transactionType"
   | "transactionCategory";
 
@@ -17,6 +18,7 @@ const SORTABLE_COLUMNS: Record<SortableColumn, Column> = {
   transactionDescription: vTransactionsFull.transactionDescription,
   amount: vTransactionsFull.amount,
   accountName: vTransactionsFull.accountName,
+  relatedAccountName: vTransactionsFull.relatedAccountName,
   transactionType: vTransactionsFull.transactionType,
   transactionCategory: vTransactionsFull.transactionCategory,
 };


### PR DESCRIPTION
Surfaces the existing related_account_name from v_transactions_full as a sortable column between Account and Type. The data was already on the row object and used by the inline edit form; only the table cell was missing.

Also adds relatedAccountName to the page-level sort whitelist in transactions/page.tsx so the header click actually re-sorts (the queries map and the page whitelist are duplicated today; tracked separately in #107).