### PR TITLE
Issue #112 - Liabilities drilldown page

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ finance-stack/
 │   │       │   ├── page.tsx              #     Summary tab (/)
 │   │       │   ├── net-worth/            #     Net Worth drill-down (from Summary KPI click)
 │   │       │   ├── assets/               #     Assets drill-down (allocation, performance, liquidity, trend)
+│   │       │   ├── liabilities/          #     Liabilities drill-down (allocation, debt-mix, waterfall, debt service, performance)
 │   │       │   ├── accounting/           #     Personal Accounting tab
 │   │       │   ├── transactions/         #     Transactions tab (form + list)
 │   │       │   ├── accounts/             #     Accounts tab (visual balance sheet)
@@ -246,6 +247,9 @@ finance-stack/
 │   │   │   ├── net-worth-timeseries-chart.tsx # Multi-series decomposition chart for net-worth drill-down (Recharts)
 │   │   │   ├── asset-allocation-chart.tsx # Treemap of assets by category → account type (Recharts)
 │   │   │   ├── assets-timeseries-chart.tsx # Stacked area chart of asset balances by category (Recharts)
+│   │   │   ├── liability-allocation-chart.tsx # Treemap of liabilities by category → account type (Recharts)
+│   │   │   ├── liabilities-timeseries-chart.tsx # Stacked area chart of liability balances by category (Recharts)
+│   │   │   ├── debt-waterfall-chart.tsx  # Debt waterfall (Start → Payments → Interest → Other → End) (Recharts)
 │   │   │   └── gauge-badge.tsx           # Custom SVG semicircular gauge with range segments
 │   │   ├── accounts/                     # Accounts page components
 │   │   │   ├── accounts-table.tsx        # Two-column balance sheet with expand/collapse; exports amountColorClass()
@@ -264,6 +268,9 @@ finance-stack/
 │   │   │   ├── net-worth-drivers-table.tsx # Expandable net worth drivers table (category → account type → account)
 │   │   │   ├── asset-performance-table.tsx # Expandable assets performance table (category → account type → account)
 │   │   │   ├── liquidity-breakdown.tsx   # Liquidity classification tiles + stacked bar
+│   │   │   ├── liability-performance-table.tsx # Expandable liability performance table (category → account type → account)
+│   │   │   ├── debt-mix-breakdown.tsx    # Debt mix tiles per account type (current vs. long-term)
+│   │   │   ├── debt-service-summary.tsx  # Period payments, interest accrued, estimated principal paid + per-account sub-table
 │   │   │   └── summary-drilldown-tabs.tsx # Sub-navigation tabs for Summary drill-down pages
 │   │   └── transactions/                 # Transaction-specific components
 │   │       ├── transaction-form.tsx      # Transaction entry form (client component)
@@ -283,9 +290,12 @@ finance-stack/
 │   │   ├── queries/dashboard.ts          # Dashboard queries (net worth, time series)
 │   │   ├── queries/net-worth-drilldown.ts # Net worth drill-down queries (waterfall, drivers, decomposition)
 │   │   ├── queries/assets-drilldown.ts   # Assets drill-down queries (allocation, performance, liquidity, decomposition)
+│   │   ├── queries/liabilities-drilldown.ts # Liabilities drill-down queries (allocation, performance, decomposition, debt service, waterfall)
+│   │   ├── queries/liability-categories.ts # Pinned transaction_category_ids for debt payments and interest expense
 │   │   ├── queries/rebuild-balance.ts    # Per-account balance history rebuild
 │   │   ├── queries/transactions.ts       # Transaction queries (filtered, sorted, form options)
 │   │   ├── queries/categories.ts         # Queries for all four reference-data tables
+│   │   ├── format/financial.ts           # Shared signed-currency, change-color, percent helpers (used by asset + liability tables)
 │   │   ├── forms/transaction.ts          # Post-submit state helper (persists Date, Account, Type across submits)
 │   │   ├── validations/account.ts        # Zod schema for account form validation
 │   │   ├── validations/transaction.ts    # Zod schema for transaction form validation
@@ -295,13 +305,17 @@ finance-stack/
 │   │   ├── unit/                         # Unit tests (no DB required)
 │   │   │   ├── validations/              #   Zod schema tests (account, transaction, categories)
 │   │   │   ├── actions/                  #   Action utility tests (buildFieldErrors)
-│   │   │   ├── components/               #   Component function tests (waterfall transform, liquidity, asset perf)
-│   │   │   └── lib/                      #   Library utility tests (cn, formatters, forms)
+│   │   │   ├── components/               #   Component function tests (waterfall transform, liquidity, asset perf, debt-mix, debt-waterfall, liability perf)
+│   │   │   └── lib/                      #   Library utility tests
+│   │   │       ├── utils.test.ts         #     cn() class-merge helper
+│   │   │       ├── forms/                #     Form helpers (transaction post-submit state)
+│   │   │       ├── format/               #     Formatters (signed-currency, change-color, percent helpers)
+│   │   │       └── queries/              #     Query module constants (liability-categories pinned IDs)
 │   │   └── integration/                  # Integration tests (requires Finances_Test DB)
 │   │       ├── setup.ts                  #   Global setup — asserts test DB URL
 │   │       ├── vitest-setup.ts           #   Per-test setup/teardown
 │   │       ├── actions/                  #   Server action tests (account, transaction)
-│   │       └── queries/                  #   Query function tests (rebuild-balance)
+│   │       └── queries/                  #   Query function tests (rebuild-balance, liabilities-drilldown)
 │   └── vitest.config.ts                  # Vitest configuration (unit + integration projects)
 ├── importer/                              # File import service
 │   ├── poll.py                            # Polling loop and parser dispatcher (committed)
@@ -360,6 +374,17 @@ docker compose down
 Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
+
+### 2026-05-02 — v0.1.2 (in progress)
+
+**Liabilities drilldown page (Issue #112)**
+- New page at `/dashboard/liabilities` mirrors the Assets drilldown structure with sections specific to debt: a 4-card KPI strip (Total / Current / Long-term liabilities, Period Change), liability allocation treemap (category → account type), stacked time-series decomposition by category, dynamic per-account-type Debt Mix tile breakdown, Debt Waterfall (Start → Payments → Interest → Other → End), Debt Service summary (period payments, interest accrued, estimated principal paid + per-account sub-table), and a 3-level expandable Liability Performance table.
+- Sign convention: liability balances are kept negative throughout. Display uses the same `signedCurrency` / `changeColor` helpers as the Assets table — `change > 0` (paydown) renders green, `change < 0` (added debt) renders red. The asset-table helpers were extracted to a new shared module `app/lib/format/financial.ts` so both tables stay in lock-step.
+- Lookup-driven design: only `account_type_category_id` (5 = Current Liability, 6 = Non-current Liability) is hard-coded in queries. `account_types` are queried dynamically per deployment. The Debt Service queries pin specific `transaction_category_id`s for payments and interest expense in `app/lib/queries/liability-categories.ts` (no name pattern matching, no `transaction_type_id` reference). Test seed and `vitest-setup.ts` extended to include all pinned categories so integration tests cover the full ID set.
+- Tests: added `tests/integration/queries/liabilities-drilldown.test.ts` with 13 cases covering all five queries (allocation, performance, decomposition, debt service, waterfall — including pinned-ID coverage and the bridge-reconciliation invariant), plus unit tests for the constants module, debt-mix tile projection, debt-waterfall bar transform, and the performance-table `% Change = "—"` empty-state.
+- Sub-nav updated: `SummaryDrilldownTabs` now has Overview / Net Worth / Assets / Liabilities. The new tab uses the existing `DashboardDateRangeFilter` with `basePath="/dashboard/liabilities"`.
+- Schema additions deferred to follow-up issue [#110](https://github.com/aellington89/finance-stack/issues/110): APR, credit limit, minimum payment, due date, original principal, term length. Each unlocks specific metrics (weighted APR, credit utilization, payoff timeline, exact principal split, upcoming-payments widget) but none are blocking for v1.
+- Lookup-row protection tracked separately as [#109](https://github.com/aellington89/finance-stack/issues/109): the pinned payment/interest `transaction_category_id` rows are user-editable today; deleting one would silently under-report debt-service totals. Closely related to [#87](https://github.com/aellington89/finance-stack/issues/87).
 
 ### 2026-05-01 — v0.1.2 (in progress)
 

--- a/app/app/(app)/dashboard/liabilities/page.tsx
+++ b/app/app/(app)/dashboard/liabilities/page.tsx
@@ -1,0 +1,137 @@
+import {
+  getDebtServiceSummary,
+  getDebtWaterfall,
+  getLiabilityAllocation,
+  getLiabilityPerformance,
+  getLiabilityTrendDecomposition,
+} from "@/lib/queries/liabilities-drilldown";
+import { LiabilityAllocationChart } from "@/components/charts/liability-allocation-chart";
+import { LiabilitiesTimeSeriesChart } from "@/components/charts/liabilities-timeseries-chart";
+import { DebtWaterfallChart } from "@/components/charts/debt-waterfall-chart";
+import { DebtMixBreakdown } from "@/components/dashboard/debt-mix-breakdown";
+import { DebtServiceSummary } from "@/components/dashboard/debt-service-summary";
+import { LiabilityPerformanceTable } from "@/components/dashboard/liability-performance-table";
+import { SummaryDrilldownTabs } from "@/components/dashboard/summary-drilldown-tabs";
+import { DashboardDateRangeFilter } from "@/components/dashboard/date-range-filter";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { changeColor, signedCurrency } from "@/lib/format/financial";
+
+export const dynamic = "force-dynamic";
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(n);
+
+export default async function LiabilitiesDrilldownPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+
+  const defaultFrom = new Date();
+  defaultFrom.setDate(defaultFrom.getDate() - 30);
+  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
+
+  const dateFrom =
+    (Array.isArray(params.dateFrom) ? params.dateFrom[0] : params.dateFrom) ||
+    defaultFromStr;
+  const dateTo =
+    (Array.isArray(params.dateTo) ? params.dateTo[0] : params.dateTo) ||
+    undefined;
+
+  const [allocation, performance, decomposition, debtService, waterfall] =
+    await Promise.all([
+      getLiabilityAllocation(dateTo),
+      getLiabilityPerformance(dateFrom, dateTo),
+      getLiabilityTrendDecomposition(dateFrom, dateTo),
+      getDebtServiceSummary(dateFrom, dateTo),
+      getDebtWaterfall(dateFrom, dateTo),
+    ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <SummaryDrilldownTabs />
+        <div className="mt-4 flex items-center justify-between">
+          <h1 className="text-2xl font-bold tracking-tight">
+            Liability Analysis
+          </h1>
+          <DashboardDateRangeFilter basePath="/dashboard/liabilities" />
+        </div>
+      </div>
+
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Total Liabilities</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-5xl font-bold tabular-nums tracking-tight">
+              {formatCurrency(allocation.totalLiabilities)}
+            </span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Current Liabilities</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-5xl font-bold tabular-nums tracking-tight">
+              {formatCurrency(allocation.currentLiabilities)}
+            </span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Long-term Liabilities</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-5xl font-bold tabular-nums tracking-tight">
+              {formatCurrency(allocation.nonCurrentLiabilities)}
+            </span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Period Change</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span
+              className={`text-5xl font-bold tabular-nums tracking-tight ${changeColor(performance.totalChange)}`}
+            >
+              {signedCurrency(performance.totalChange)}
+            </span>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="h-[500px]">
+          <LiabilityAllocationChart data={allocation} />
+        </div>
+        <div className="h-[500px]">
+          <LiabilitiesTimeSeriesChart decomposition={decomposition} />
+        </div>
+      </div>
+
+      <DebtMixBreakdown data={allocation} />
+
+      <div className="h-[400px]">
+        <DebtWaterfallChart data={waterfall} />
+      </div>
+
+      <DebtServiceSummary data={debtService} />
+
+      <LiabilityPerformanceTable data={performance} />
+    </div>
+  );
+}

--- a/app/app/(app)/dashboard/page.tsx
+++ b/app/app/(app)/dashboard/page.tsx
@@ -107,24 +107,19 @@ export default async function DashboardSummaryPage({
 
             {/* Gauge badges row */}
             <div className="flex flex-1 items-center justify-evenly gap-4">
-              <Link
-                href="/dashboard/assets"
-                className="group rounded-md p-2 transition-colors hover:bg-accent"
-              >
-                <GaugeBadge
-                  title="Assets per $ of Debt"
-                  label={`$${assetToLiability.toFixed(2)}`}
-                  value={assetToLiability}
-                  min={0}
-                  max={3}
-                  segments={[
-                    { max: 1, color: RANGE_COLORS.red },
-                    { max: 1.5, color: RANGE_COLORS.yellow },
-                    { max: 2, color: RANGE_COLORS.green },
-                    { max: 3, color: RANGE_COLORS.blue },
-                  ]}
-                />
-              </Link>
+              <GaugeBadge
+                title="Assets per $ of Debt"
+                label={`$${assetToLiability.toFixed(2)}`}
+                value={assetToLiability}
+                min={0}
+                max={3}
+                segments={[
+                  { max: 1, color: RANGE_COLORS.red },
+                  { max: 1.5, color: RANGE_COLORS.yellow },
+                  { max: 2, color: RANGE_COLORS.green },
+                  { max: 3, color: RANGE_COLORS.blue },
+                ]}
+              />
               <GaugeBadge
                 title="% Owned Assets"
                 label={`${nwToAsset.toFixed(2)}%`}
@@ -186,6 +181,7 @@ export default async function DashboardSummaryPage({
               data={timeSeries}
               dataKey="totalLiabilities"
               color={COLORS.liabilities}
+              href="/dashboard/liabilities"
             />
           </div>
         </CardContent>

--- a/app/components/charts/debt-waterfall-chart.tsx
+++ b/app/components/charts/debt-waterfall-chart.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from "recharts";
+import type { DebtWaterfallData } from "@/lib/queries/liabilities-drilldown";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// Color semantics on the liability side:
+//   payments → balance moves toward zero (good)  → green
+//   interest → balance moves away from zero (bad)→ red
+//   other    → can go either way; signed at runtime
+const COLORS = {
+  good: "#2eb88a",
+  bad: "#e23670",
+  neutral: "#6b7280",
+};
+
+const chartConfig: ChartConfig = {
+  value: { label: "Change", color: COLORS.neutral },
+};
+
+const formatCurrencyCompact = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+
+const formatCurrencyFull = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+export interface DebtWaterfallBar {
+  name: string;
+  base: number;
+  value: number;
+  displayValue: number;
+  type: "start" | "end" | "good" | "bad" | "neutral";
+}
+
+/**
+ * Transforms the waterfall query result into Recharts stacked-bar shape:
+ * each bar has a transparent `base` and a visible `value`. Liability
+ * balances are negative throughout, so the bridge math runs naturally:
+ *   start + payments + interest + other = end
+ *
+ * Bar `type` carries the *intent* (paydown vs. added debt) so the colorer
+ * can paint without re-deriving signs:
+ *   - payments are paydowns (positive on the liability side) → "good"
+ *   - interest accrual is added debt (negative) → "bad"
+ *   - "other" is signed: positive (paydown of unclassified change) → good,
+ *     negative (e.g. new credit-card spend) → bad.
+ */
+export function buildDebtWaterfallBars(
+  data: DebtWaterfallData
+): DebtWaterfallBar[] {
+  const bars: DebtWaterfallBar[] = [];
+
+  // Start
+  bars.push({
+    name: "Start",
+    base: Math.min(0, data.startBalance),
+    value: Math.abs(data.startBalance),
+    displayValue: data.startBalance,
+    type: "start",
+  });
+
+  let running = data.startBalance;
+
+  const pushChange = (
+    name: string,
+    delta: number,
+    type: DebtWaterfallBar["type"]
+  ) => {
+    if (delta === 0) return;
+    const isPositive = delta > 0;
+    bars.push({
+      name,
+      base: isPositive ? running : running + delta,
+      value: Math.abs(delta),
+      displayValue: delta,
+      type,
+    });
+    running += delta;
+  };
+
+  pushChange("Payments", data.payments, "good");
+  pushChange("Interest", data.interestAccrued, "bad");
+  pushChange("Other", data.other, data.other >= 0 ? "good" : "bad");
+
+  // End
+  bars.push({
+    name: "End",
+    base: Math.min(0, data.endBalance),
+    value: Math.abs(data.endBalance),
+    displayValue: data.endBalance,
+    type: "end",
+  });
+
+  return bars;
+}
+
+function getBarColor(type: DebtWaterfallBar["type"]): string {
+  if (type === "good") return COLORS.good;
+  if (type === "bad") return COLORS.bad;
+  return COLORS.neutral;
+}
+
+interface DebtWaterfallChartProps {
+  data: DebtWaterfallData;
+}
+
+export function DebtWaterfallChart({ data }: DebtWaterfallChartProps) {
+  const bars = buildDebtWaterfallBars(data);
+  const isEmpty = data.startBalance === 0 && data.endBalance === 0;
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Debt Waterfall</CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col">
+        {isEmpty ? (
+          <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+            No liability activity in the selected range.
+          </div>
+        ) : (
+          <ChartContainer config={chartConfig} className="min-h-0 flex-1 w-full">
+            <BarChart data={bars} margin={{ left: 8, right: 8 }}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="name"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                interval={0}
+                tick={{ fontSize: 11 }}
+              />
+              <YAxis
+                tickFormatter={formatCurrencyCompact}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={70}
+              />
+              <ChartTooltip
+                content={({ active, payload, label }) => (
+                  <ChartTooltipContent
+                    active={active}
+                    label={label}
+                    payload={payload?.filter((p) => p.dataKey === "value")}
+                    formatter={(_, __, item) => {
+                      const bar = item?.payload as DebtWaterfallBar | undefined;
+                      if (!bar) return null;
+                      const prefix =
+                        bar.type === "start" || bar.type === "end"
+                          ? ""
+                          : bar.displayValue > 0
+                            ? "+"
+                            : "";
+                      return (
+                        <span className="font-bold tabular-nums">
+                          {prefix}
+                          {formatCurrencyFull(bar.displayValue)}
+                        </span>
+                      );
+                    }}
+                    labelFormatter={(label) => String(label)}
+                  />
+                )}
+              />
+              <Bar dataKey="base" stackId="waterfall" fill="transparent" />
+              <Bar dataKey="value" stackId="waterfall" radius={[4, 4, 0, 0]}>
+                {bars.map((bar, idx) => (
+                  <Cell key={idx} fill={getBarColor(bar.type)} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/charts/liabilities-timeseries-chart.tsx
+++ b/app/components/charts/liabilities-timeseries-chart.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useMemo } from "react";
+import { format } from "date-fns";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { LiabilityDecompositionPoint } from "@/lib/queries/liabilities-drilldown";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const CATEGORY_COLORS: Record<number, string> = {
+  5: "#e23670",
+  6: "#c2185b",
+};
+
+const formatCurrencyCompact = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+
+const formatCurrencyFull = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const formatDate = (dateStr: string) => {
+  const d = new Date(dateStr + "T00:00:00");
+  return format(d, "MMM d");
+};
+
+interface SeriesInfo {
+  key: string;
+  label: string;
+  color: string;
+  categoryId: number;
+}
+
+interface PivotedRow {
+  date: string;
+  [seriesKey: string]: number | string;
+}
+
+function pivotByCategory(points: LiabilityDecompositionPoint[]): {
+  rows: PivotedRow[];
+  series: SeriesInfo[];
+} {
+  const seriesMap = new Map<number, SeriesInfo>();
+  for (const p of points) {
+    if (!seriesMap.has(p.categoryId)) {
+      seriesMap.set(p.categoryId, {
+        key: `cat_${p.categoryId}`,
+        label: p.categoryName,
+        color: CATEGORY_COLORS[p.categoryId] ?? "#6b7280",
+        categoryId: p.categoryId,
+      });
+    }
+  }
+
+  const series = Array.from(seriesMap.values()).sort(
+    (a, b) => a.categoryId - b.categoryId
+  );
+
+  const dateMap = new Map<string, PivotedRow>();
+  for (const p of points) {
+    if (!dateMap.has(p.date)) {
+      const row: PivotedRow = { date: p.date };
+      for (const s of series) row[s.key] = 0;
+      dateMap.set(p.date, row);
+    }
+    const row = dateMap.get(p.date)!;
+    const key = `cat_${p.categoryId}`;
+    row[key] = ((row[key] as number) || 0) + p.cumulativeBalance;
+  }
+
+  const rows = Array.from(dateMap.values()).sort((a, b) =>
+    a.date.localeCompare(b.date)
+  );
+
+  return { rows, series };
+}
+
+interface LiabilitiesTimeSeriesChartProps {
+  decomposition: LiabilityDecompositionPoint[];
+}
+
+export function LiabilitiesTimeSeriesChart({
+  decomposition,
+}: LiabilitiesTimeSeriesChartProps) {
+  const { rows, series } = useMemo(
+    () => pivotByCategory(decomposition),
+    [decomposition]
+  );
+
+  const chartConfig: ChartConfig = Object.fromEntries(
+    series.map((s) => [s.key, { label: s.label, color: s.color }])
+  );
+
+  const isEmpty = rows.length === 0;
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          Liabilities Over Time (by category)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col">
+        {isEmpty ? (
+          <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+            No liability balance history in the selected range.
+          </div>
+        ) : (
+          <ChartContainer config={chartConfig} className="min-h-0 flex-1 w-full">
+            <AreaChart data={rows} margin={{ left: 8, right: 8 }}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="date"
+                tickFormatter={formatDate}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={32}
+              />
+              <YAxis
+                tickFormatter={formatCurrencyCompact}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={70}
+                domain={["auto", 0]}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(_, payload) => {
+                      if (!payload?.[0]?.payload?.date) return "";
+                      const d = new Date(
+                        payload[0].payload.date + "T00:00:00"
+                      );
+                      return format(d, "MMM d, yyyy");
+                    }}
+                    formatter={(value, name) => (
+                      <div className="flex flex-1 justify-between gap-4">
+                        <span className="font-bold">
+                          {chartConfig[name as string]?.label ?? name}:
+                        </span>
+                        <span className="tabular-nums">
+                          {formatCurrencyFull(value as number)}
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              {series.map((s) => (
+                <Area
+                  key={s.key}
+                  type="monotone"
+                  dataKey={s.key}
+                  stackId="liabilities"
+                  stroke={s.color}
+                  fill={s.color}
+                  fillOpacity={0.4}
+                  strokeWidth={2}
+                />
+              ))}
+            </AreaChart>
+          </ChartContainer>
+        )}
+        <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-3 text-xs text-muted-foreground">
+          {series.map((s) => (
+            <div key={s.key} className="flex items-center gap-1.5">
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: s.color }}
+                aria-hidden
+              />
+              <span>{s.label}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/charts/liability-allocation-chart.tsx
+++ b/app/components/charts/liability-allocation-chart.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useMemo } from "react";
+import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
+import type { LiabilityAllocationData } from "@/lib/queries/liabilities-drilldown";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// Stable per-category palette. Categories themselves are stable lookups
+// (5 = Current Liability, 6 = Non-current Liability) so hard-coding keys
+// is safe — but account types under each category are dynamic and assigned
+// shaded variants in `shadeForType`.
+const CATEGORY_COLORS: Record<number, string> = {
+  5: "#e23670", // Current Liability — pink
+  6: "#c2185b", // Non-current Liability — darker pink
+};
+
+const TYPE_SHADES = ["#e23670", "#d6336c", "#c2185b", "#a01457", "#7c1054"];
+
+const formatCurrencyCompact = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+
+const formatCurrencyFull = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+interface TreemapNode {
+  name: string;
+  size?: number;
+  rawValue?: number;
+  categoryId?: number;
+  categoryName?: string;
+  accountTypeId?: number;
+  percentOfTotal?: number;
+  percentOfParent?: number;
+  children?: TreemapNode[];
+}
+
+interface LiabilityAllocationChartProps {
+  data: LiabilityAllocationData;
+}
+
+interface ContentProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  name?: string;
+  size?: number;
+  rawValue?: number;
+  categoryId?: number;
+  accountTypeId?: number;
+  percentOfTotal?: number;
+  depth?: number;
+}
+
+function TreemapContent(props: ContentProps) {
+  const {
+    x = 0,
+    y = 0,
+    width = 0,
+    height = 0,
+    depth,
+    name,
+    rawValue,
+    categoryId,
+    accountTypeId,
+    percentOfTotal,
+  } = props;
+
+  if (depth !== 2) return <g />;
+
+  const baseColor = categoryId ? CATEGORY_COLORS[categoryId] ?? "#6b7280" : "#6b7280";
+  // Use the type id to pick a stable shade within the category palette.
+  const shade =
+    accountTypeId != null
+      ? TYPE_SHADES[accountTypeId % TYPE_SHADES.length]
+      : baseColor;
+
+  const canLabel = width > 70 && height > 32;
+  const canDetails = width > 90 && height > 52;
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        style={{
+          fill: shade,
+          stroke: "#fff",
+          strokeWidth: 2,
+          strokeOpacity: 0.8,
+        }}
+      />
+      {canLabel && (
+        <text x={x + 6} y={y + 16} fill="#fff" fontSize={11} fontWeight={600}>
+          {name}
+        </text>
+      )}
+      {canDetails && rawValue != null && (
+        <text x={x + 6} y={y + 32} fill="#fff" fontSize={10} opacity={0.85}>
+          {formatCurrencyCompact(rawValue)}
+          {percentOfTotal != null ? ` · ${percentOfTotal.toFixed(1)}%` : ""}
+        </text>
+      )}
+    </g>
+  );
+}
+
+interface TreemapTooltipPayload {
+  name?: string;
+  size?: number;
+  rawValue?: number;
+  categoryName?: string;
+  percentOfTotal?: number;
+  percentOfParent?: number;
+}
+
+function TreemapTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload?: TreemapTooltipPayload }[];
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const datum = payload[0].payload;
+  if (!datum || datum.rawValue == null) return null;
+  return (
+    <div className="rounded-md border bg-popover px-3 py-2 text-xs shadow-md">
+      <div className="font-medium">{datum.name}</div>
+      {datum.categoryName && (
+        <div className="text-muted-foreground">{datum.categoryName}</div>
+      )}
+      <div className="mt-1 tabular-nums">
+        {formatCurrencyFull(datum.rawValue)}
+      </div>
+      {datum.percentOfTotal != null && (
+        <div className="text-muted-foreground tabular-nums">
+          {datum.percentOfTotal.toFixed(2)}% of total
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function LiabilityAllocationChart({
+  data,
+}: LiabilityAllocationChartProps) {
+  // Treemap tile size must be a positive number, but liability balances are
+  // negative. Use the absolute value for `size` (controls tile area) and
+  // surface the raw signed value separately for labels and tooltips.
+  const treeData: TreemapNode[] = useMemo(() => {
+    return data.byCategory.map((cat) => ({
+      name: cat.categoryName,
+      categoryId: cat.categoryId,
+      categoryName: cat.categoryName,
+      children: cat.children.map((child) => ({
+        name: child.accountTypeName,
+        size: Math.abs(child.value),
+        rawValue: child.value,
+        categoryId: cat.categoryId,
+        categoryName: cat.categoryName,
+        accountTypeId: child.accountTypeId,
+        percentOfTotal: child.percentOfTotal,
+        percentOfParent: child.percentOfParent,
+      })),
+    }));
+  }, [data]);
+
+  const isEmpty =
+    data.byCategory.length === 0 || data.totalLiabilities === 0;
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          Liability Allocation
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-3">
+        <div className="min-h-0 flex-1">
+          {isEmpty ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              No liability balances in the selected range.
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <Treemap
+                data={treeData}
+                dataKey="size"
+                nameKey="name"
+                stroke="#fff"
+                isAnimationActive={false}
+                content={<TreemapContent />}
+              >
+                <Tooltip content={<TreemapTooltip />} />
+              </Treemap>
+            </ResponsiveContainer>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-1 text-xs text-muted-foreground">
+          {data.byCategory.map((cat) => (
+            <div key={cat.categoryId} className="flex items-center gap-1.5">
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: CATEGORY_COLORS[cat.categoryId] ?? "#6b7280",
+                }}
+                aria-hidden
+              />
+              <span>
+                {cat.categoryName} · {cat.percentOfTotal.toFixed(1)}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/dashboard/debt-mix-breakdown.tsx
+++ b/app/components/dashboard/debt-mix-breakdown.tsx
@@ -1,0 +1,167 @@
+import type { LiabilityAllocationData } from "@/lib/queries/liabilities-drilldown";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// Deterministic palette for type tiles. Indexed by `account_type_id` so the
+// same type always renders in the same color across loads, without
+// hard-coding any specific type id.
+const PALETTE = [
+  "#e23670",
+  "#f97316",
+  "#eab308",
+  "#2eb88a",
+  "#2662d9",
+  "#8b5cf6",
+  "#06b6d4",
+  "#a16207",
+];
+
+const colorForType = (typeId: number): string =>
+  PALETTE[typeId % PALETTE.length];
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+
+export interface DebtMixTile {
+  accountTypeId: number;
+  accountTypeName: string;
+  categoryId: number;
+  color: string;
+  value: number;
+  percent: number;
+}
+
+/**
+ * Flattens the allocation tree to one tile per account type with a
+ * non-zero balance. Sorted from largest debt magnitude to smallest.
+ */
+export function buildDebtMixTiles(data: LiabilityAllocationData): DebtMixTile[] {
+  const tiles: DebtMixTile[] = [];
+  for (const cat of data.byCategory) {
+    for (const child of cat.children) {
+      if (child.value === 0) continue;
+      tiles.push({
+        accountTypeId: child.accountTypeId,
+        accountTypeName: child.accountTypeName,
+        categoryId: cat.categoryId,
+        color: colorForType(child.accountTypeId),
+        value: child.value,
+        percent: child.percentOfTotal,
+      });
+    }
+  }
+  // Largest magnitude first.
+  tiles.sort((a, b) => Math.abs(b.value) - Math.abs(a.value));
+  return tiles;
+}
+
+interface DebtMixBreakdownProps {
+  data: LiabilityAllocationData;
+}
+
+export function DebtMixBreakdown({ data }: DebtMixBreakdownProps) {
+  const tiles = buildDebtMixTiles(data);
+
+  if (tiles.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Debt Mix</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-sm text-muted-foreground">
+            No outstanding liabilities.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Cap the grid at 5 columns on desktop; the tile count varies by deployment.
+  // Static class strings only — Tailwind cannot purge dynamic class names.
+  const colsClass = (() => {
+    switch (Math.min(tiles.length, 5)) {
+      case 1:
+        return "grid-cols-1";
+      case 2:
+        return "grid-cols-2";
+      case 3:
+        return "grid-cols-2 md:grid-cols-3";
+      case 4:
+        return "grid-cols-2 md:grid-cols-4";
+      default:
+        return "grid-cols-2 md:grid-cols-5";
+    }
+  })();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Debt Mix</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className={`grid gap-3 ${colsClass}`}>
+          {tiles.map((tile) => (
+            <div
+              key={tile.accountTypeId}
+              data-testid={`debt-mix-tile-${tile.accountTypeId}`}
+              className="rounded-lg border p-3"
+            >
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: tile.color }}
+                  aria-hidden
+                />
+                <span>{tile.accountTypeName}</span>
+              </div>
+              <div className="mt-1 text-xl font-semibold tabular-nums tracking-tight">
+                {formatCurrency(tile.value)}
+              </div>
+              <div className="text-xs text-muted-foreground tabular-nums">
+                {tile.percent.toFixed(1)}%
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          className="flex h-2 w-full overflow-hidden rounded-full bg-muted"
+          role="img"
+          aria-label="Debt mix distribution"
+        >
+          {tiles.map((tile) => {
+            if (tile.percent <= 0) return null;
+            return (
+              <div
+                key={tile.accountTypeId}
+                data-testid={`debt-mix-bar-${tile.accountTypeId}`}
+                style={{
+                  width: `${tile.percent}%`,
+                  backgroundColor: tile.color,
+                }}
+                title={`${tile.accountTypeName}: ${tile.percent.toFixed(1)}%`}
+              />
+            );
+          })}
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Total:{" "}
+          <span className="font-medium tabular-nums text-foreground">
+            {formatCurrency(data.totalLiabilities)}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/dashboard/debt-service-summary.tsx
+++ b/app/components/dashboard/debt-service-summary.tsx
@@ -27,6 +27,9 @@ const formatCurrency = (n: number) =>
     maximumFractionDigits: 2,
   }).format(n);
 
+const formatPctOfPayment = (numerator: number, payments: number) =>
+  payments === 0 ? "—" : `${((numerator / payments) * 100).toFixed(1)}%`;
+
 interface DebtServiceSummaryProps {
   data: DebtServiceData;
 }
@@ -128,7 +131,9 @@ export function DebtServiceSummary({ data }: DebtServiceSummaryProps) {
                     <TableHead>Name</TableHead>
                     <TableHead className="text-right">Payments</TableHead>
                     <TableHead className="text-right">Interest</TableHead>
+                    <TableHead className="text-right">% of Payment</TableHead>
                     <TableHead className="text-right">Principal</TableHead>
+                    <TableHead className="text-right">% of Payment</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -156,8 +161,20 @@ export function DebtServiceSummary({ data }: DebtServiceSummaryProps) {
                           <TableCell className="text-right tabular-nums">
                             {formatCurrency(Math.abs(cat.interestAccrued))}
                           </TableCell>
+                          <TableCell className="text-right tabular-nums text-muted-foreground">
+                            {formatPctOfPayment(
+                              Math.abs(cat.interestAccrued),
+                              cat.totalPayments
+                            )}
+                          </TableCell>
                           <TableCell className="text-right tabular-nums">
                             {formatCurrency(cat.principalPaid)}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums text-muted-foreground">
+                            {formatPctOfPayment(
+                              cat.principalPaid,
+                              cat.totalPayments
+                            )}
                           </TableCell>
                         </TableRow>
                         {catOpen &&
@@ -189,8 +206,20 @@ export function DebtServiceSummary({ data }: DebtServiceSummaryProps) {
                                       Math.abs(type.interestAccrued)
                                     )}
                                   </TableCell>
+                                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                                    {formatPctOfPayment(
+                                      Math.abs(type.interestAccrued),
+                                      type.totalPayments
+                                    )}
+                                  </TableCell>
                                   <TableCell className="text-right tabular-nums">
                                     {formatCurrency(type.principalPaid)}
+                                  </TableCell>
+                                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                                    {formatPctOfPayment(
+                                      type.principalPaid,
+                                      type.totalPayments
+                                    )}
                                   </TableCell>
                                 </TableRow>
                                 {typeOpen &&
@@ -210,8 +239,20 @@ export function DebtServiceSummary({ data }: DebtServiceSummaryProps) {
                                           Math.abs(acc.interestAccrued)
                                         )}
                                       </TableCell>
+                                      <TableCell className="text-right tabular-nums text-muted-foreground">
+                                        {formatPctOfPayment(
+                                          Math.abs(acc.interestAccrued),
+                                          acc.totalPayments
+                                        )}
+                                      </TableCell>
                                       <TableCell className="text-right tabular-nums">
                                         {formatCurrency(acc.principalPaid)}
+                                      </TableCell>
+                                      <TableCell className="text-right tabular-nums text-muted-foreground">
+                                        {formatPctOfPayment(
+                                          acc.principalPaid,
+                                          acc.totalPayments
+                                        )}
                                       </TableCell>
                                     </TableRow>
                                   ))}
@@ -231,8 +272,17 @@ export function DebtServiceSummary({ data }: DebtServiceSummaryProps) {
                     <TableCell className="text-right font-bold tabular-nums">
                       {formatCurrency(interestCost)}
                     </TableCell>
+                    <TableCell className="text-right font-bold tabular-nums text-muted-foreground">
+                      {formatPctOfPayment(interestCost, data.totalPayments)}
+                    </TableCell>
                     <TableCell className="text-right font-bold tabular-nums">
                       {formatCurrency(data.principalPaid)}
+                    </TableCell>
+                    <TableCell className="text-right font-bold tabular-nums text-muted-foreground">
+                      {formatPctOfPayment(
+                        data.principalPaid,
+                        data.totalPayments
+                      )}
                     </TableCell>
                   </TableRow>
                 </TableFooter>

--- a/app/components/dashboard/debt-service-summary.tsx
+++ b/app/components/dashboard/debt-service-summary.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import type { DebtServiceData } from "@/lib/queries/liabilities-drilldown";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+
+interface DebtServiceSummaryProps {
+  data: DebtServiceData;
+}
+
+/**
+ * Sign convention recap for this card:
+ *   - `totalPayments` is positive on the liability side (paydown).
+ *   - `interestAccrued` is negative on the liability side (added debt).
+ *     We display its absolute value as "interest cost".
+ *   - `principalPaid = totalPayments + interestAccrued`, naturally positive
+ *     when payments exceed interest.
+ */
+export function DebtServiceSummary({ data }: DebtServiceSummaryProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const rowRefs = useRef<Map<string, HTMLTableRowElement | null>>(new Map());
+  const pendingScroll = useRef<{ key: string; top: number } | null>(null);
+
+  const toggle = (key: string) => {
+    const row = rowRefs.current.get(key);
+    if (row) {
+      pendingScroll.current = {
+        key,
+        top: row.getBoundingClientRect().top,
+      };
+    }
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  useLayoutEffect(() => {
+    const pending = pendingScroll.current;
+    if (!pending) return;
+    const row = rowRefs.current.get(pending.key);
+    if (row) {
+      const delta = row.getBoundingClientRect().top - pending.top;
+      if (delta !== 0) window.scrollBy(0, delta);
+    }
+    pendingScroll.current = null;
+  }, [expanded]);
+
+  const setRowRef = (key: string) => (el: HTMLTableRowElement | null) => {
+    if (el) rowRefs.current.set(key, el);
+    else rowRefs.current.delete(key);
+  };
+
+  const interestCost = Math.abs(data.interestAccrued);
+  const isEmpty =
+    data.totalPayments === 0 &&
+    data.interestAccrued === 0 &&
+    data.categories.length === 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Debt Service</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isEmpty ? (
+          <div className="text-sm text-muted-foreground">
+            No payment or interest activity in the selected range.
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-3 grid-cols-1 md:grid-cols-3">
+              <div className="rounded-lg border p-3">
+                <div className="text-xs text-muted-foreground">
+                  Total Payments
+                </div>
+                <div className="mt-1 text-xl font-semibold tabular-nums tracking-tight">
+                  {formatCurrency(data.totalPayments)}
+                </div>
+              </div>
+              <div className="rounded-lg border p-3">
+                <div className="text-xs text-muted-foreground">
+                  Interest Accrued
+                </div>
+                <div className="mt-1 text-xl font-semibold tabular-nums tracking-tight text-red-600 dark:text-red-400">
+                  {formatCurrency(interestCost)}
+                </div>
+              </div>
+              <div className="rounded-lg border p-3">
+                <div className="text-xs text-muted-foreground">
+                  Principal Paid (estimated)
+                </div>
+                <div className="mt-1 text-xl font-semibold tabular-nums tracking-tight text-green-600 dark:text-green-400">
+                  {formatCurrency(data.principalPaid)}
+                </div>
+              </div>
+            </div>
+
+            {data.categories.length > 0 && (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead className="text-right">Payments</TableHead>
+                    <TableHead className="text-right">Interest</TableHead>
+                    <TableHead className="text-right">Principal</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.categories.map((cat) => {
+                    const catKey = `cat:${cat.categoryId}`;
+                    const catOpen = expanded.has(catKey);
+                    const Chevron = catOpen ? ChevronDown : ChevronRight;
+                    return (
+                      <Fragment key={catKey}>
+                        <TableRow
+                          ref={setRowRef(catKey)}
+                          className="cursor-pointer"
+                          onClick={() => toggle(catKey)}
+                          data-testid={`row-${catKey}`}
+                        >
+                          <TableCell className="text-muted-foreground">
+                            <span className="inline-flex items-center gap-1">
+                              <Chevron className="h-4 w-4" />
+                              {cat.categoryName}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatCurrency(cat.totalPayments)}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatCurrency(Math.abs(cat.interestAccrued))}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatCurrency(cat.principalPaid)}
+                          </TableCell>
+                        </TableRow>
+                        {catOpen &&
+                          cat.accountTypes.map((type) => {
+                            const typeKey = `type:${cat.categoryId}:${type.accountTypeId}`;
+                            const typeOpen = expanded.has(typeKey);
+                            const TypeChevron = typeOpen
+                              ? ChevronDown
+                              : ChevronRight;
+                            return (
+                              <Fragment key={typeKey}>
+                                <TableRow
+                                  ref={setRowRef(typeKey)}
+                                  className="cursor-pointer"
+                                  onClick={() => toggle(typeKey)}
+                                  data-testid={`row-${typeKey}`}
+                                >
+                                  <TableCell className="text-muted-foreground pl-8">
+                                    <span className="inline-flex items-center gap-1">
+                                      <TypeChevron className="h-4 w-4" />
+                                      {type.accountTypeName}
+                                    </span>
+                                  </TableCell>
+                                  <TableCell className="text-right tabular-nums">
+                                    {formatCurrency(type.totalPayments)}
+                                  </TableCell>
+                                  <TableCell className="text-right tabular-nums">
+                                    {formatCurrency(
+                                      Math.abs(type.interestAccrued)
+                                    )}
+                                  </TableCell>
+                                  <TableCell className="text-right tabular-nums">
+                                    {formatCurrency(type.principalPaid)}
+                                  </TableCell>
+                                </TableRow>
+                                {typeOpen &&
+                                  type.accounts.map((acc) => (
+                                    <TableRow
+                                      key={`acc:${cat.categoryId}:${type.accountTypeId}:${acc.accountId}`}
+                                      data-testid={`row-acc:${acc.accountId}`}
+                                    >
+                                      <TableCell className="text-muted-foreground pl-14">
+                                        {acc.accountName}
+                                      </TableCell>
+                                      <TableCell className="text-right tabular-nums">
+                                        {formatCurrency(acc.totalPayments)}
+                                      </TableCell>
+                                      <TableCell className="text-right tabular-nums">
+                                        {formatCurrency(
+                                          Math.abs(acc.interestAccrued)
+                                        )}
+                                      </TableCell>
+                                      <TableCell className="text-right tabular-nums">
+                                        {formatCurrency(acc.principalPaid)}
+                                      </TableCell>
+                                    </TableRow>
+                                  ))}
+                              </Fragment>
+                            );
+                          })}
+                      </Fragment>
+                    );
+                  })}
+                </TableBody>
+                <TableFooter>
+                  <TableRow>
+                    <TableCell className="font-bold">Total</TableCell>
+                    <TableCell className="text-right font-bold tabular-nums">
+                      {formatCurrency(data.totalPayments)}
+                    </TableCell>
+                    <TableCell className="text-right font-bold tabular-nums">
+                      {formatCurrency(interestCost)}
+                    </TableCell>
+                    <TableCell className="text-right font-bold tabular-nums">
+                      {formatCurrency(data.principalPaid)}
+                    </TableCell>
+                  </TableRow>
+                </TableFooter>
+              </Table>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              Principal/interest split is estimated from accrued-interest
+              categories and may not match servicer statements exactly.
+            </p>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/dashboard/liability-performance-table.tsx
+++ b/app/components/dashboard/liability-performance-table.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useLayoutEffect, useRef, useState } from "react";
 import { ChevronRight, ChevronDown } from "lucide-react";
-import type { PerformanceData } from "@/lib/queries/assets-drilldown";
+import type { LiabilityPerformanceData } from "@/lib/queries/liabilities-drilldown";
 import {
   signedCurrency,
   signedPercent,
@@ -32,11 +32,18 @@ const formatCurrency = (n: number) =>
     maximumFractionDigits: 2,
   }).format(n);
 
-interface AssetPerformanceTableProps {
-  data: PerformanceData;
+// `% Change` is undefined for accounts opened mid-period (start_balance = 0).
+// Render an em-dash so the column reads cleanly without claiming 0% or ∞%.
+export const formatPercentChange = (n: number | null): string =>
+  n === null ? "—" : signedPercent(n);
+
+interface LiabilityPerformanceTableProps {
+  data: LiabilityPerformanceData;
 }
 
-export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
+export function LiabilityPerformanceTable({
+  data,
+}: LiabilityPerformanceTableProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const rowRefs = useRef<Map<string, HTMLTableRowElement | null>>(new Map());
   const pendingScroll = useRef<{ key: string; top: number } | null>(null);
@@ -73,17 +80,23 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
     else rowRefs.current.delete(key);
   };
 
+  // `% of Total` divides current value by total current value. Both are
+  // negative, so the ratio is positive — display as a normal percent.
+  const totalIsNonZero = data.totalCurrentValue !== 0;
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-medium">Asset Performance</CardTitle>
+        <CardTitle className="text-sm font-medium">
+          Liability Performance
+        </CardTitle>
       </CardHeader>
       <CardContent>
         <Table>
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
-              <TableHead className="text-right">Value</TableHead>
+              <TableHead className="text-right">Balance</TableHead>
               <TableHead className="text-right">Change</TableHead>
               <TableHead className="text-right">% Change</TableHead>
               <TableHead className="text-right">% of Total</TableHead>
@@ -117,9 +130,13 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                       {signedCurrency(cat.change)}
                     </TableCell>
                     <TableCell
-                      className={`text-right tabular-nums ${changeColor(cat.percentChange)}`}
+                      className={`text-right tabular-nums ${
+                        cat.percentChange !== null
+                          ? changeColor(cat.percentChange)
+                          : ""
+                      }`}
                     >
-                      {signedPercent(cat.percentChange)}
+                      {formatPercentChange(cat.percentChange)}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
                       {cat.percentOfTotal.toFixed(2)}%
@@ -155,9 +172,13 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                               {signedCurrency(type.change)}
                             </TableCell>
                             <TableCell
-                              className={`text-right tabular-nums ${changeColor(type.percentChange)}`}
+                              className={`text-right tabular-nums ${
+                                type.percentChange !== null
+                                  ? changeColor(type.percentChange)
+                                  : ""
+                              }`}
                             >
-                              {signedPercent(type.percentChange)}
+                              {formatPercentChange(type.percentChange)}
                             </TableCell>
                             <TableCell className="text-right tabular-nums">
                               {type.percentOfTotal.toFixed(2)}%
@@ -181,9 +202,13 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                                   {signedCurrency(acc.change)}
                                 </TableCell>
                                 <TableCell
-                                  className={`text-right tabular-nums ${changeColor(acc.percentChange)}`}
+                                  className={`text-right tabular-nums ${
+                                    acc.percentChange !== null
+                                      ? changeColor(acc.percentChange)
+                                      : ""
+                                  }`}
                                 >
-                                  {signedPercent(acc.percentChange)}
+                                  {formatPercentChange(acc.percentChange)}
                                 </TableCell>
                                 <TableCell className="text-right tabular-nums">
                                   {acc.percentOfTotal.toFixed(2)}%
@@ -209,12 +234,16 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                 {signedCurrency(data.totalChange)}
               </TableCell>
               <TableCell
-                className={`text-right font-bold tabular-nums ${changeColor(data.totalPercentChange)}`}
+                className={`text-right font-bold tabular-nums ${
+                  data.totalPercentChange !== null
+                    ? changeColor(data.totalPercentChange)
+                    : ""
+                }`}
               >
-                {signedPercent(data.totalPercentChange)}
+                {formatPercentChange(data.totalPercentChange)}
               </TableCell>
               <TableCell className="text-right font-bold tabular-nums">
-                {data.totalCurrentValue > 0 ? "100.00%" : "0.00%"}
+                {totalIsNonZero ? "100.00%" : "0.00%"}
               </TableCell>
             </TableRow>
           </TableFooter>

--- a/app/components/dashboard/summary-drilldown-tabs.tsx
+++ b/app/components/dashboard/summary-drilldown-tabs.tsx
@@ -7,6 +7,7 @@ const drilldownTabs = [
   { value: "overview", label: "Overview", href: "/dashboard" },
   { value: "net-worth", label: "Net Worth", href: "/dashboard/net-worth" },
   { value: "assets", label: "Assets", href: "/dashboard/assets" },
+  { value: "liabilities", label: "Liabilities", href: "/dashboard/liabilities" },
 ] as const;
 
 function getActiveDrilldown(pathname: string): string {

--- a/app/lib/format/financial.ts
+++ b/app/lib/format/financial.ts
@@ -1,0 +1,27 @@
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+
+export function signedCurrency(n: number): string {
+  const formatted = formatCurrency(Math.abs(n));
+  if (n > 0) return `+${formatted}`;
+  if (n < 0) return `-${formatted}`;
+  return formatted;
+}
+
+export function signedPercent(n: number): string {
+  const abs = Math.abs(n).toFixed(2);
+  if (n > 0) return `+${abs}%`;
+  if (n < 0) return `-${abs}%`;
+  return `${abs}%`;
+}
+
+export function changeColor(n: number): string {
+  if (n > 0) return "text-green-600 dark:text-green-400";
+  if (n < 0) return "text-red-600 dark:text-red-400";
+  return "";
+}

--- a/app/lib/queries/liabilities-drilldown.ts
+++ b/app/lib/queries/liabilities-drilldown.ts
@@ -1,0 +1,749 @@
+import { db } from "@/lib/db";
+import { sql, type SQL } from "drizzle-orm";
+import {
+  DEBT_INTEREST_CATEGORY_IDS,
+  DEBT_PAYMENT_CATEGORY_IDS,
+  LIABILITY_CATEGORY_IDS,
+  LIABILITY_CURRENT_CATEGORY_ID,
+  LIABILITY_NON_CURRENT_CATEGORY_ID,
+} from "@/lib/queries/liability-categories";
+
+// Sign convention: liability balances are stored as negative numbers in
+// account_balance_history. We preserve that sign throughout — this module
+// returns raw cumulative_balance values (negative for outstanding debt).
+// Transaction sums also preserve their natural sign on the liability side:
+// payments are positive (paydown moves balance toward zero), interest accruals
+// are negative (added debt moves balance further from zero).
+
+// Build a parameterized SQL fragment for `IN (...)` from a numeric tuple.
+const inList = (ids: readonly number[]): SQL =>
+  sql.join(
+    ids.map((id) => sql`${id}`),
+    sql`, `
+  );
+
+const LIABILITY_IDS = inList(LIABILITY_CATEGORY_IDS);
+const PAYMENT_IDS = inList(DEBT_PAYMENT_CATEGORY_IDS);
+const INTEREST_IDS = inList(DEBT_INTEREST_CATEGORY_IDS);
+const DEBT_SERVICE_IDS = inList([
+  ...DEBT_PAYMENT_CATEGORY_IDS,
+  ...DEBT_INTEREST_CATEGORY_IDS,
+]);
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface AllocationAccountType {
+  accountTypeId: number;
+  accountTypeName: string;
+  value: number;
+  percentOfParent: number;
+  percentOfTotal: number;
+}
+
+export interface AllocationCategory {
+  categoryId: number;
+  categoryName: string;
+  value: number;
+  percentOfTotal: number;
+  children: AllocationAccountType[];
+}
+
+export interface LiabilityAllocationData {
+  totalLiabilities: number;
+  currentLiabilities: number;
+  nonCurrentLiabilities: number;
+  asOf: string;
+  byCategory: AllocationCategory[];
+}
+
+export interface PerformanceAccount {
+  accountId: number;
+  accountName: string;
+  currentValue: number;
+  startValue: number;
+  change: number;
+  percentChange: number | null;
+  percentOfParent: number;
+  percentOfTotal: number;
+}
+
+export interface PerformanceAccountType {
+  accountTypeId: number;
+  accountTypeName: string;
+  currentValue: number;
+  startValue: number;
+  change: number;
+  percentChange: number | null;
+  percentOfParent: number;
+  percentOfTotal: number;
+  accounts: PerformanceAccount[];
+}
+
+export interface PerformanceCategory {
+  categoryId: number;
+  categoryName: string;
+  currentValue: number;
+  startValue: number;
+  change: number;
+  percentChange: number | null;
+  percentOfTotal: number;
+  accountTypes: PerformanceAccountType[];
+}
+
+export interface LiabilityPerformanceData {
+  totalCurrentValue: number;
+  totalStartValue: number;
+  totalChange: number;
+  totalPercentChange: number | null;
+  categories: PerformanceCategory[];
+}
+
+export interface LiabilityDecompositionPoint {
+  date: string;
+  categoryId: number;
+  categoryName: string;
+  accountTypeId: number;
+  accountTypeName: string;
+  accountId: number;
+  accountName: string;
+  cumulativeBalance: number;
+}
+
+export interface DebtServiceAccount {
+  accountId: number;
+  accountName: string;
+  totalPayments: number;
+  interestAccrued: number;
+  principalPaid: number;
+}
+
+export interface DebtServiceAccountType {
+  accountTypeId: number;
+  accountTypeName: string;
+  totalPayments: number;
+  interestAccrued: number;
+  principalPaid: number;
+  accounts: DebtServiceAccount[];
+}
+
+export interface DebtServiceCategory {
+  categoryId: number;
+  categoryName: string;
+  totalPayments: number;
+  interestAccrued: number;
+  principalPaid: number;
+  accountTypes: DebtServiceAccountType[];
+}
+
+export interface DebtServiceData {
+  totalPayments: number;
+  interestAccrued: number;
+  principalPaid: number;
+  categories: DebtServiceCategory[];
+}
+
+export interface DebtWaterfallData {
+  startBalance: number;
+  endBalance: number;
+  payments: number;
+  interestAccrued: number;
+  other: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const pct = (num: number, den: number) =>
+  den !== 0 ? round2((num / den) * 100) : 0;
+
+// `% Change` is undefined when the start balance is zero (e.g. an account
+// opened mid-period). Return null so the UI can render "—".
+const pctOrNull = (num: number, den: number): number | null =>
+  den !== 0 ? round2((num / den) * 100) : null;
+
+// ── Queries ────────────────────────────────────────────────────────
+
+/**
+ * Snapshot of liability allocation as of `dateTo` (default: latest balance
+ * date per account). Returns nested structure (category → account type)
+ * suitable for a treemap. Values are negative magnitudes (raw balances).
+ */
+export async function getLiabilityAllocation(
+  dateTo?: string
+): Promise<LiabilityAllocationData> {
+  // Accounts closed on or before the as-of date contribute nothing — their
+  // last balance_history row is the day before closure (rebuild-balance.ts:33)
+  // and would otherwise be picked up by the per-account MAX(balance_date).
+  const asOfExpr = dateTo ? sql`${dateTo}::date` : sql`CURRENT_DATE`;
+  const dateFilter = dateTo
+    ? sql`abh.balance_date = ${dateTo}::date`
+    : sql`abh.balance_date = (
+        SELECT MAX(balance_date) FROM account_balance_history
+        WHERE account_id = abh.account_id
+      )`;
+
+  const result = await db.execute(sql`
+    SELECT
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      MAX(abh.balance_date) AS as_of,
+      COALESCE(SUM(abh.cumulative_balance), 0) AS value
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    WHERE atc.account_type_category_id IN (${LIABILITY_IDS})
+      AND (a.closed_date IS NULL OR a.closed_date > ${asOfExpr})
+      AND ${dateFilter}
+    GROUP BY
+      atc.account_type_category_id, atc.account_type_category,
+      at.account_type_id, at.account_type
+    ORDER BY atc.account_type_category_id, at.account_type_id
+  `);
+
+  type Row = {
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    as_of: string | null;
+    value: string;
+  };
+
+  const rows = result.rows as Row[];
+
+  const catMap = new Map<
+    number,
+    {
+      categoryId: number;
+      categoryName: string;
+      value: number;
+      children: { id: number; name: string; value: number }[];
+    }
+  >();
+
+  let asOf: string | null = null;
+
+  for (const row of rows) {
+    const value = parseFloat(row.value) || 0;
+    if (row.as_of && (!asOf || row.as_of > asOf)) {
+      asOf = row.as_of;
+    }
+
+    let cat = catMap.get(row.category_id);
+    if (!cat) {
+      cat = {
+        categoryId: row.category_id,
+        categoryName: row.category_name,
+        value: 0,
+        children: [],
+      };
+      catMap.set(row.category_id, cat);
+    }
+    cat.value += value;
+    cat.children.push({
+      id: row.account_type_id,
+      name: row.account_type_name,
+      value,
+    });
+  }
+
+  const totalLiabilities = Array.from(catMap.values()).reduce(
+    (s, c) => s + c.value,
+    0
+  );
+  const currentLiabilities = catMap.get(LIABILITY_CURRENT_CATEGORY_ID)?.value ?? 0;
+  const nonCurrentLiabilities =
+    catMap.get(LIABILITY_NON_CURRENT_CATEGORY_ID)?.value ?? 0;
+
+  // Most-negative first (largest debt by magnitude).
+  const byCategory: AllocationCategory[] = Array.from(catMap.values())
+    .map((cat) => ({
+      categoryId: cat.categoryId,
+      categoryName: cat.categoryName,
+      value: cat.value,
+      percentOfTotal: pct(cat.value, totalLiabilities),
+      children: cat.children
+        .map((c) => ({
+          accountTypeId: c.id,
+          accountTypeName: c.name,
+          value: c.value,
+          percentOfParent: pct(c.value, cat.value),
+          percentOfTotal: pct(c.value, totalLiabilities),
+        }))
+        .sort((a, b) => a.value - b.value),
+    }))
+    .sort((a, b) => a.value - b.value);
+
+  return {
+    totalLiabilities,
+    currentLiabilities,
+    nonCurrentLiabilities,
+    asOf: asOf ?? "",
+    byCategory,
+  };
+}
+
+/**
+ * Hierarchical period-over-period change (category → type → account) for
+ * liability categories only. `change > 0` means the (negative) balance moved
+ * toward zero — i.e. debt was paid down. `% Change` is computed against
+ * `|startValue|` so its sign matches `change`: a paydown reads as `+X%`
+ * (good, green) and a balance increase reads as `-X%` (bad, red). `% Change`
+ * is `null` when the start balance is zero (new debt opened mid-period).
+ */
+export async function getLiabilityPerformance(
+  dateFrom: string,
+  dateTo?: string
+): Promise<LiabilityPerformanceData> {
+  const endDate = dateTo ?? sql`CURRENT_DATE`;
+
+  const result = await db.execute(sql`
+    SELECT
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      a.account_id,
+      a.account_name,
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    WHERE atc.account_type_category_id IN (${LIABILITY_IDS})
+      AND abh.balance_date IN (${dateFrom}::date, ${endDate}::date)
+    GROUP BY
+      atc.account_type_category_id, atc.account_type_category,
+      at.account_type_id, at.account_type,
+      a.account_id, a.account_name
+    ORDER BY atc.account_type_category_id, at.account_type_id, a.account_id
+  `);
+
+  type Row = {
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    account_id: number;
+    account_name: string;
+    start_balance: string;
+    end_balance: string;
+  };
+
+  const rows = result.rows as Row[];
+
+  const catMap = new Map<
+    number,
+    {
+      categoryId: number;
+      categoryName: string;
+      currentValue: number;
+      startValue: number;
+      types: Map<
+        number,
+        {
+          accountTypeId: number;
+          accountTypeName: string;
+          currentValue: number;
+          startValue: number;
+          accounts: {
+            accountId: number;
+            accountName: string;
+            currentValue: number;
+            startValue: number;
+          }[];
+        }
+      >;
+    }
+  >();
+
+  for (const row of rows) {
+    const startValue = parseFloat(row.start_balance) || 0;
+    const currentValue = parseFloat(row.end_balance) || 0;
+
+    let cat = catMap.get(row.category_id);
+    if (!cat) {
+      cat = {
+        categoryId: row.category_id,
+        categoryName: row.category_name,
+        currentValue: 0,
+        startValue: 0,
+        types: new Map(),
+      };
+      catMap.set(row.category_id, cat);
+    }
+    cat.currentValue += currentValue;
+    cat.startValue += startValue;
+
+    let type = cat.types.get(row.account_type_id);
+    if (!type) {
+      type = {
+        accountTypeId: row.account_type_id,
+        accountTypeName: row.account_type_name,
+        currentValue: 0,
+        startValue: 0,
+        accounts: [],
+      };
+      cat.types.set(row.account_type_id, type);
+    }
+    type.currentValue += currentValue;
+    type.startValue += startValue;
+    type.accounts.push({
+      accountId: row.account_id,
+      accountName: row.account_name,
+      currentValue,
+      startValue,
+    });
+  }
+
+  const totalCurrentValue = Array.from(catMap.values()).reduce(
+    (s, c) => s + c.currentValue,
+    0
+  );
+  const totalStartValue = Array.from(catMap.values()).reduce(
+    (s, c) => s + c.startValue,
+    0
+  );
+  const totalChange = totalCurrentValue - totalStartValue;
+
+  const categories: PerformanceCategory[] = Array.from(catMap.values())
+    .map((cat) => {
+      const catChange = cat.currentValue - cat.startValue;
+
+      const accountTypes: PerformanceAccountType[] = Array.from(
+        cat.types.values()
+      )
+        .map((t) => {
+          const typeChange = t.currentValue - t.startValue;
+
+          const accounts = t.accounts
+            .map((a) => {
+              const change = a.currentValue - a.startValue;
+              return {
+                accountId: a.accountId,
+                accountName: a.accountName,
+                currentValue: a.currentValue,
+                startValue: a.startValue,
+                change,
+                percentChange: pctOrNull(change, Math.abs(a.startValue)),
+                percentOfParent: pct(a.currentValue, t.currentValue),
+                percentOfTotal: pct(a.currentValue, totalCurrentValue),
+              };
+            })
+            // Largest debt by magnitude first.
+            .sort((x, y) => x.currentValue - y.currentValue);
+
+          return {
+            accountTypeId: t.accountTypeId,
+            accountTypeName: t.accountTypeName,
+            currentValue: t.currentValue,
+            startValue: t.startValue,
+            change: typeChange,
+            percentChange: pctOrNull(typeChange, Math.abs(t.startValue)),
+            percentOfParent: pct(t.currentValue, cat.currentValue),
+            percentOfTotal: pct(t.currentValue, totalCurrentValue),
+            accounts,
+          };
+        })
+        .sort((x, y) => x.currentValue - y.currentValue);
+
+      return {
+        categoryId: cat.categoryId,
+        categoryName: cat.categoryName,
+        currentValue: cat.currentValue,
+        startValue: cat.startValue,
+        change: catChange,
+        percentChange: pctOrNull(catChange, Math.abs(cat.startValue)),
+        percentOfTotal: pct(cat.currentValue, totalCurrentValue),
+        accountTypes,
+      };
+    })
+    .sort((x, y) => x.currentValue - y.currentValue);
+
+  return {
+    totalCurrentValue,
+    totalStartValue,
+    totalChange,
+    totalPercentChange: pctOrNull(totalChange, Math.abs(totalStartValue)),
+    categories,
+  };
+}
+
+/**
+ * Daily cumulative balance per liability account, for the stacked
+ * time-series decomposition chart. Values are negative magnitudes.
+ */
+export async function getLiabilityTrendDecomposition(
+  dateFrom?: string,
+  dateTo?: string
+): Promise<LiabilityDecompositionPoint[]> {
+  const conditions: SQL[] = [
+    sql`atc.account_type_category_id IN (${LIABILITY_IDS})`,
+  ];
+
+  if (dateFrom) {
+    conditions.push(sql`abh.balance_date >= ${dateFrom}`);
+  }
+  if (dateTo) {
+    conditions.push(sql`abh.balance_date <= ${dateTo}`);
+  }
+
+  const whereClause = sql`WHERE ${sql.join(conditions, sql` AND `)}`;
+
+  const result = await db.execute(sql`
+    SELECT
+      abh.balance_date AS date,
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      a.account_id,
+      a.account_name,
+      abh.cumulative_balance
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    ${whereClause}
+    ORDER BY abh.balance_date ASC, atc.account_type_category_id, a.account_id
+  `);
+
+  type Row = {
+    date: string;
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    account_id: number;
+    account_name: string;
+    cumulative_balance: string;
+  };
+
+  return (result.rows as Row[]).map((row) => ({
+    date: row.date,
+    categoryId: row.category_id,
+    categoryName: row.category_name,
+    accountTypeId: row.account_type_id,
+    accountTypeName: row.account_type_name,
+    accountId: row.account_id,
+    accountName: row.account_name,
+    cumulativeBalance: parseFloat(row.cumulative_balance) || 0,
+  }));
+}
+
+/**
+ * Aggregates payment and interest-accrual transactions on liability
+ * accounts over the period. Returns a hierarchical structure (category →
+ * account type → account) mirroring `getLiabilityPerformance`. Values
+ * preserve their natural sign on the liability side: payments are positive
+ * (paydown), interest is negative (added debt). `principalPaid =
+ * totalPayments + interestAccrued` because the negative interest sum
+ * subtracts the interest portion.
+ */
+export async function getDebtServiceSummary(
+  dateFrom: string,
+  dateTo?: string
+): Promise<DebtServiceData> {
+  const endDate = dateTo ?? sql`CURRENT_DATE`;
+
+  const result = await db.execute(sql`
+    SELECT
+      atc.account_type_category_id AS category_id,
+      atc.account_type_category AS category_name,
+      at.account_type_id,
+      at.account_type AS account_type_name,
+      a.account_id,
+      a.account_name,
+      COALESCE(SUM(CASE WHEN t.transaction_category_id IN (${PAYMENT_IDS})
+        THEN t.amount ELSE 0 END), 0) AS payments,
+      COALESCE(SUM(CASE WHEN t.transaction_category_id IN (${INTEREST_IDS})
+        THEN t.amount ELSE 0 END), 0) AS interest
+    FROM transactions t
+    JOIN accounts a ON a.account_id = t.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    JOIN account_type_categories atc
+      ON atc.account_type_category_id = at.account_type_category_id
+    WHERE atc.account_type_category_id IN (${LIABILITY_IDS})
+      AND t.transaction_date BETWEEN ${dateFrom}::date AND ${endDate}::date
+      AND t.transaction_category_id IN (${DEBT_SERVICE_IDS})
+    GROUP BY
+      atc.account_type_category_id, atc.account_type_category,
+      at.account_type_id, at.account_type,
+      a.account_id, a.account_name
+    ORDER BY atc.account_type_category_id, at.account_type_id, a.account_name
+  `);
+
+  type Row = {
+    category_id: number;
+    category_name: string;
+    account_type_id: number;
+    account_type_name: string;
+    account_id: number;
+    account_name: string;
+    payments: string;
+    interest: string;
+  };
+
+  const rows = result.rows as Row[];
+
+  const catMap = new Map<
+    number,
+    {
+      categoryId: number;
+      categoryName: string;
+      totalPayments: number;
+      interestAccrued: number;
+      types: Map<
+        number,
+        {
+          accountTypeId: number;
+          accountTypeName: string;
+          totalPayments: number;
+          interestAccrued: number;
+          accounts: DebtServiceAccount[];
+        }
+      >;
+    }
+  >();
+
+  for (const row of rows) {
+    const totalPayments = parseFloat(row.payments) || 0;
+    const interestAccrued = parseFloat(row.interest) || 0;
+    const principalPaid = totalPayments + interestAccrued;
+
+    let cat = catMap.get(row.category_id);
+    if (!cat) {
+      cat = {
+        categoryId: row.category_id,
+        categoryName: row.category_name,
+        totalPayments: 0,
+        interestAccrued: 0,
+        types: new Map(),
+      };
+      catMap.set(row.category_id, cat);
+    }
+    cat.totalPayments += totalPayments;
+    cat.interestAccrued += interestAccrued;
+
+    let type = cat.types.get(row.account_type_id);
+    if (!type) {
+      type = {
+        accountTypeId: row.account_type_id,
+        accountTypeName: row.account_type_name,
+        totalPayments: 0,
+        interestAccrued: 0,
+        accounts: [],
+      };
+      cat.types.set(row.account_type_id, type);
+    }
+    type.totalPayments += totalPayments;
+    type.interestAccrued += interestAccrued;
+    type.accounts.push({
+      accountId: row.account_id,
+      accountName: row.account_name,
+      totalPayments,
+      interestAccrued,
+      principalPaid,
+    });
+  }
+
+  const categories: DebtServiceCategory[] = Array.from(catMap.values()).map(
+    (cat) => ({
+      categoryId: cat.categoryId,
+      categoryName: cat.categoryName,
+      totalPayments: cat.totalPayments,
+      interestAccrued: cat.interestAccrued,
+      principalPaid: cat.totalPayments + cat.interestAccrued,
+      accountTypes: Array.from(cat.types.values()).map((t) => ({
+        accountTypeId: t.accountTypeId,
+        accountTypeName: t.accountTypeName,
+        totalPayments: t.totalPayments,
+        interestAccrued: t.interestAccrued,
+        principalPaid: t.totalPayments + t.interestAccrued,
+        accounts: t.accounts,
+      })),
+    })
+  );
+
+  const totalPayments = categories.reduce((s, c) => s + c.totalPayments, 0);
+  const interestAccrued = categories.reduce(
+    (s, c) => s + c.interestAccrued,
+    0
+  );
+
+  return {
+    totalPayments,
+    interestAccrued,
+    principalPaid: totalPayments + interestAccrued,
+    categories,
+  };
+}
+
+/**
+ * Bridges start balance to end balance via payments, interest, and a
+ * residual "other" bar that closes the difference. All values preserve
+ * their natural sign on the liability side, so `start + payments +
+ * interest + other = end` reconciles directly.
+ */
+export async function getDebtWaterfall(
+  dateFrom: string,
+  dateTo?: string
+): Promise<DebtWaterfallData> {
+  const endDate = dateTo ?? sql`CURRENT_DATE`;
+
+  const balanceResult = await db.execute(sql`
+    SELECT
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
+      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
+        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+    FROM account_balance_history abh
+    JOIN accounts a ON a.account_id = abh.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    WHERE at.account_type_category_id IN (${LIABILITY_IDS})
+      AND abh.balance_date IN (${dateFrom}::date, ${endDate}::date)
+  `);
+
+  const balanceRow = (balanceResult.rows as {
+    start_balance: string;
+    end_balance: string;
+  }[])[0];
+  const startBalance = parseFloat(balanceRow?.start_balance) || 0;
+  const endBalance = parseFloat(balanceRow?.end_balance) || 0;
+
+  const txResult = await db.execute(sql`
+    SELECT
+      COALESCE(SUM(CASE WHEN t.transaction_category_id IN (${PAYMENT_IDS})
+        THEN t.amount ELSE 0 END), 0) AS payments,
+      COALESCE(SUM(CASE WHEN t.transaction_category_id IN (${INTEREST_IDS})
+        THEN t.amount ELSE 0 END), 0) AS interest
+    FROM transactions t
+    JOIN accounts a ON a.account_id = t.account_id
+    JOIN account_types at ON at.account_type_id = a.account_type_id
+    WHERE at.account_type_category_id IN (${LIABILITY_IDS})
+      AND t.transaction_date BETWEEN ${dateFrom}::date AND ${endDate}::date
+  `);
+
+  const txRow = (txResult.rows as { payments: string; interest: string }[])[0];
+  const payments = parseFloat(txRow?.payments) || 0;
+  const interestAccrued = parseFloat(txRow?.interest) || 0;
+
+  const other = endBalance - startBalance - payments - interestAccrued;
+
+  return {
+    startBalance,
+    endBalance,
+    payments,
+    interestAccrued,
+    other,
+  };
+}

--- a/app/lib/queries/liability-categories.ts
+++ b/app/lib/queries/liability-categories.ts
@@ -7,14 +7,18 @@
 // rows must not be deleted via /settings/categories.
 //
 // Categorization scheme (see docs/Liability Tracking.md):
-//   • DEBT_INTEREST_CATEGORY_IDS — "Accrued *" categories. Posted on the
-//     liability side as a NEGATIVE amount (added debt).
+//   • DEBT_INTEREST_CATEGORY_IDS — interest charges that ADD to the
+//     liability balance. Posted on the liability side as a NEGATIVE amount
+//     (added debt). Includes the "Accrued *" categories for loans and
+//     "Credit Card Interest" finance charges (credit cards don't split into
+//     accrued/paid the way installment loans do — the finance charge is the
+//     accrual).
 //   • DEBT_PAYMENT_CATEGORY_IDS — paid principal/interest expenses on the
-//     liability side, plus "Applied Credit" for credit-card paydowns and
-//     "Credit Card Interest" finance charges. Posted as POSITIVE on the
-//     liability side (paydown). Cash-side "*Payment" categories (1/2/3/4/
-//     54/58/79) are intentionally excluded — they only appear on the
-//     checking leg and would never match the liability-side WHERE filter.
+//     liability side, plus "Applied Credit" for credit-card paydowns. Posted
+//     as POSITIVE on the liability side (paydown). Cash-side "*Payment"
+//     categories (1/2/3/4/54/58/79) are intentionally excluded — they only
+//     appear on the checking leg and would never match the liability-side
+//     WHERE filter.
 //
 // SCHEMA LIMITATION: these IDs are hard-coded against the seeded
 // transaction_categories rows. If a user adds a custom category for a new
@@ -46,13 +50,13 @@ export const DEBT_PAYMENT_CATEGORY_IDS = [
   70, // Auto Loan Principle
   75, // Student Loan Principle
   76, // Student Loan Interest
-  80, // Credit Card Interest
 ] as const;
 
-// Accrued interest that adds to the liability balance (posted negative).
+// Interest charges that add to the liability balance (posted negative).
 export const DEBT_INTEREST_CATEGORY_IDS = [
   9, // Accrued HELOC Interest
   14, // Accrued Mortgage Interest
   69, // Accrued Auto Loan Interest
   74, // Accrued Student Loan Interest
+  80, // Credit Card Interest
 ] as const;

--- a/app/lib/queries/liability-categories.ts
+++ b/app/lib/queries/liability-categories.ts
@@ -1,0 +1,58 @@
+// Pinned IDs the Liabilities drilldown depends on.
+//
+// account_type_category_id values come from init-db/seeds/shared-lookups.sql
+// and are stable across deployments. transaction_category_id values are
+// pinned by ID to the production Finances DB rather than matched by name —
+// this avoids fragility from rename/pattern mismatches but means the seeded
+// rows must not be deleted via /settings/categories.
+//
+// Categorization scheme (see docs/Liability Tracking.md):
+//   • DEBT_INTEREST_CATEGORY_IDS — "Accrued *" categories. Posted on the
+//     liability side as a NEGATIVE amount (added debt).
+//   • DEBT_PAYMENT_CATEGORY_IDS — paid principal/interest expenses on the
+//     liability side, plus "Applied Credit" for credit-card paydowns and
+//     "Credit Card Interest" finance charges. Posted as POSITIVE on the
+//     liability side (paydown). Cash-side "*Payment" categories (1/2/3/4/
+//     54/58/79) are intentionally excluded — they only appear on the
+//     checking leg and would never match the liability-side WHERE filter.
+//
+// SCHEMA LIMITATION: these IDs are hard-coded against the seeded
+// transaction_categories rows. If a user adds a custom category for a new
+// loan type (e.g. "Personal Loan Principle") via /settings/categories, it
+// will not be picked up by the debt-service / waterfall queries. A future
+// fix needs a "released"/standard-mapping concept on transaction_categories
+// so user-owned rows can opt into these aggregates. Track separately.
+
+export const LIABILITY_CURRENT_CATEGORY_ID = 5;
+export const LIABILITY_NON_CURRENT_CATEGORY_ID = 6;
+
+export const LIABILITY_CATEGORY_IDS = [
+  LIABILITY_CURRENT_CATEGORY_ID,
+  LIABILITY_NON_CURRENT_CATEGORY_ID,
+] as const;
+
+// Paid principal + paid interest legs that post to the liability account.
+// `principalPaid = totalPayments + interestAccrued` reconciles because the
+// paid-interest categories (8/13/68/76) offset the accrued-interest
+// categories (9/14/69/74) when summed in the same period.
+export const DEBT_PAYMENT_CATEGORY_IDS = [
+  7, // HELOC Principle
+  8, // HELOC Interest
+  12, // Mortgage Principle
+  13, // Mortgage Interest
+  29, // Applied Credit (credit-card paydown)
+  57, // Epic Loan Interest
+  68, // Auto Loan Interest
+  70, // Auto Loan Principle
+  75, // Student Loan Principle
+  76, // Student Loan Interest
+  80, // Credit Card Interest
+] as const;
+
+// Accrued interest that adds to the liability balance (posted negative).
+export const DEBT_INTEREST_CATEGORY_IDS = [
+  9, // Accrued HELOC Interest
+  14, // Accrued Mortgage Interest
+  69, // Accrued Auto Loan Interest
+  74, // Accrued Student Loan Interest
+] as const;

--- a/app/tests/integration/queries/liabilities-drilldown.test.ts
+++ b/app/tests/integration/queries/liabilities-drilldown.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  accountBalanceHistory,
+  transactions,
+} from "@/drizzle/schema";
+import { inArray } from "drizzle-orm";
+import {
+  getDebtServiceSummary,
+  getDebtWaterfall,
+  getLiabilityAllocation,
+  getLiabilityPerformance,
+  getLiabilityTrendDecomposition,
+  type DebtServiceAccount,
+  type DebtServiceData,
+} from "@/lib/queries/liabilities-drilldown";
+
+function findDebtServiceAccount(
+  data: DebtServiceData,
+  accountId: number
+): DebtServiceAccount | undefined {
+  for (const cat of data.categories) {
+    for (const type of cat.accountTypes) {
+      const acc = type.accounts.find((a) => a.accountId === accountId);
+      if (acc) return acc;
+    }
+  }
+  return undefined;
+}
+import {
+  DEBT_INTEREST_CATEGORY_IDS,
+  DEBT_PAYMENT_CATEGORY_IDS,
+} from "@/lib/queries/liability-categories";
+
+// Test dates — outside the 12-month mock-data window so queries scoped to
+// these dates only return rows this file inserts.
+const SNAPSHOT_DATE = "2020-06-30";
+const PERF_START = "2020-01-01";
+const PERF_END = "2020-12-31";
+
+// Account-type IDs from init-db/seeds/finances-test-mock-data.sql.
+const TYPE_CHECKING = 2; // Current Asset
+const TYPE_CREDIT_CARD = 15; // Current Liability
+const TYPE_MORTGAGE = 17; // Non-current Liability
+const TYPE_AUTO_LOAN = 19; // Non-current Liability
+
+const createdAccountIds: number[] = [];
+const createdTxIds: number[] = [];
+
+async function createAccount(
+  name: string,
+  accountTypeId: number
+): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({ accountName: name, accountTypeId })
+    .returning({ accountId: accounts.accountId });
+  createdAccountIds.push(row.accountId);
+  return row.accountId;
+}
+
+async function insertBalance(
+  accountId: number,
+  balanceDate: string,
+  cumulativeBalance: string
+) {
+  await db.insert(accountBalanceHistory).values({
+    accountId,
+    balanceDate,
+    dailyBalance: "0.00",
+    cumulativeBalance,
+  });
+}
+
+async function insertTx(
+  accountId: number,
+  date: string,
+  amount: string,
+  transactionCategoryId: number,
+  transactionTypeId = 2
+): Promise<number> {
+  const [row] = await db
+    .insert(transactions)
+    .values({
+      transactionDescription: "test",
+      transactionDate: date,
+      accountId,
+      amount,
+      transactionTypeId,
+      transactionCategoryId,
+    })
+    .returning({ transactionId: transactions.transactionId });
+  createdTxIds.push(row.transactionId);
+  return row.transactionId;
+}
+
+afterEach(async () => {
+  if (createdTxIds.length > 0) {
+    await db
+      .delete(transactions)
+      .where(inArray(transactions.transactionId, createdTxIds));
+    createdTxIds.length = 0;
+  }
+  if (createdAccountIds.length > 0) {
+    await db
+      .delete(accountBalanceHistory)
+      .where(inArray(accountBalanceHistory.accountId, createdAccountIds));
+    await db
+      .delete(accounts)
+      .where(inArray(accounts.accountId, createdAccountIds));
+    createdAccountIds.length = 0;
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getLiabilityAllocation
+// ────────────────────────────────────────────────────────────────────
+
+describe("getLiabilityAllocation", () => {
+  it("aggregates negative balances by category and account type", async () => {
+    const cardId = await createAccount("Alloc Card", TYPE_CREDIT_CARD);
+    const mortgageId = await createAccount("Alloc Mortgage", TYPE_MORTGAGE);
+    const autoId = await createAccount("Alloc Auto", TYPE_AUTO_LOAN);
+    const checkingId = await createAccount("Alloc Checking", TYPE_CHECKING);
+
+    await insertBalance(cardId, SNAPSHOT_DATE, "-500.00");
+    await insertBalance(mortgageId, SNAPSHOT_DATE, "-200000.00");
+    await insertBalance(autoId, SNAPSHOT_DATE, "-15000.00");
+    await insertBalance(checkingId, SNAPSHOT_DATE, "5000.00");
+
+    const result = await getLiabilityAllocation(SNAPSHOT_DATE);
+
+    // Total is negative — raw sign preserved.
+    expect(result.totalLiabilities).toBe(-500 - 200000 - 15000);
+    expect(result.currentLiabilities).toBe(-500);
+    expect(result.nonCurrentLiabilities).toBe(-215000);
+
+    // No asset categories.
+    for (const cat of result.byCategory) {
+      expect([5, 6]).toContain(cat.categoryId);
+    }
+
+    // Children sum to parent.
+    for (const cat of result.byCategory) {
+      const childSum = cat.children.reduce((s, c) => s + c.value, 0);
+      expect(childSum).toBeCloseTo(cat.value, 2);
+    }
+  });
+
+  it("category percentOfTotal sums to ~100", async () => {
+    const cardId = await createAccount("Pct Card", TYPE_CREDIT_CARD);
+    const mortgageId = await createAccount("Pct Mortgage", TYPE_MORTGAGE);
+    await insertBalance(cardId, SNAPSHOT_DATE, "-1000.00");
+    await insertBalance(mortgageId, SNAPSHOT_DATE, "-3000.00");
+
+    const result = await getLiabilityAllocation(SNAPSHOT_DATE);
+
+    const pctSum = result.byCategory.reduce(
+      (s, c) => s + c.percentOfTotal,
+      0
+    );
+    expect(pctSum).toBeGreaterThan(99.5);
+    expect(pctSum).toBeLessThan(100.5);
+  });
+
+  it("returns an empty allocation for a date with no liabilities", async () => {
+    const result = await getLiabilityAllocation("1999-01-01");
+    expect(result.totalLiabilities).toBe(0);
+    expect(result.byCategory).toHaveLength(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getLiabilityPerformance
+// ────────────────────────────────────────────────────────────────────
+
+describe("getLiabilityPerformance", () => {
+  it("returns hierarchical change with category = sum(type) = sum(account)", async () => {
+    const cardId = await createAccount("Perf Card", TYPE_CREDIT_CARD);
+    const mortgageId = await createAccount("Perf Mortgage", TYPE_MORTGAGE);
+
+    await insertBalance(cardId, PERF_START, "-1000.00");
+    await insertBalance(cardId, PERF_END, "-800.00"); // paid down 200
+    await insertBalance(mortgageId, PERF_START, "-200000.00");
+    await insertBalance(mortgageId, PERF_END, "-195000.00"); // paid down 5000
+
+    const result = await getLiabilityPerformance(PERF_START, PERF_END);
+
+    expect(result.totalCurrentValue).toBe(-800 + -195000);
+    expect(result.totalStartValue).toBe(-1000 + -200000);
+    // change > 0 = paydown.
+    expect(result.totalChange).toBeCloseTo(5200, 2);
+
+    for (const cat of result.categories) {
+      expect([5, 6]).toContain(cat.categoryId);
+      expect(cat.change).toBeCloseTo(cat.currentValue - cat.startValue, 2);
+
+      const typeSum = cat.accountTypes.reduce(
+        (s, t) => s + t.currentValue,
+        0
+      );
+      expect(typeSum).toBeCloseTo(cat.currentValue, 2);
+
+      for (const type of cat.accountTypes) {
+        const acctSum = type.accounts.reduce(
+          (s, a) => s + a.currentValue,
+          0
+        );
+        expect(acctSum).toBeCloseTo(type.currentValue, 2);
+      }
+    }
+  });
+
+  it("returns null percentChange when start balance is zero", async () => {
+    const cardId = await createAccount("New Card", TYPE_CREDIT_CARD);
+    // Account opened mid-period: start_balance = 0, end_balance = -250.
+    await insertBalance(cardId, PERF_START, "0.00");
+    await insertBalance(cardId, PERF_END, "-250.00");
+
+    const result = await getLiabilityPerformance(PERF_START, PERF_END);
+
+    const cat = result.categories.find((c) => c.categoryId === 5);
+    const type = cat?.accountTypes.find(
+      (t) => t.accountTypeId === TYPE_CREDIT_CARD
+    );
+    const acct = type?.accounts.find((a) => a.accountId === cardId);
+    expect(acct?.percentChange).toBeNull();
+  });
+
+  it("scopes to liability categories only (asset rows excluded)", async () => {
+    const cardId = await createAccount("Scope Card", TYPE_CREDIT_CARD);
+    const checkingId = await createAccount("Scope Checking", TYPE_CHECKING);
+
+    await insertBalance(cardId, PERF_START, "-100.00");
+    await insertBalance(cardId, PERF_END, "-50.00");
+    await insertBalance(checkingId, PERF_START, "1000.00");
+    await insertBalance(checkingId, PERF_END, "1500.00");
+
+    const result = await getLiabilityPerformance(PERF_START, PERF_END);
+
+    for (const cat of result.categories) {
+      expect([5, 6]).toContain(cat.categoryId);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getLiabilityTrendDecomposition
+// ────────────────────────────────────────────────────────────────────
+
+describe("getLiabilityTrendDecomposition", () => {
+  it("returns rows only for liability categories within the date range", async () => {
+    const cardId = await createAccount("Trend Card", TYPE_CREDIT_CARD);
+    const mortgageId = await createAccount("Trend Mortgage", TYPE_MORTGAGE);
+    const checkingId = await createAccount("Trend Checking", TYPE_CHECKING);
+
+    await insertBalance(cardId, PERF_START, "-100.00");
+    await insertBalance(cardId, PERF_END, "-50.00");
+    await insertBalance(mortgageId, PERF_START, "-50000.00");
+    await insertBalance(mortgageId, PERF_END, "-49500.00");
+    await insertBalance(checkingId, PERF_START, "200.00");
+
+    const rows = await getLiabilityTrendDecomposition(PERF_START, PERF_END);
+
+    for (const r of rows) {
+      expect([5, 6]).toContain(r.categoryId);
+      expect(r.cumulativeBalance).toBeLessThanOrEqual(0);
+      expect(r.date >= PERF_START && r.date <= PERF_END).toBe(true);
+    }
+
+    const myIds = new Set([cardId, mortgageId]);
+    const mine = rows.filter((r) => myIds.has(r.accountId));
+    expect(mine).toHaveLength(4);
+  });
+
+  it("respects dateFrom/dateTo bounds", async () => {
+    const cardId = await createAccount("Bounds Card", TYPE_CREDIT_CARD);
+    await insertBalance(cardId, "2019-01-01", "-50.00");
+    await insertBalance(cardId, "2020-06-30", "-100.00");
+    await insertBalance(cardId, "2021-12-31", "-150.00");
+
+    const rows = await getLiabilityTrendDecomposition(
+      "2020-01-01",
+      "2020-12-31"
+    );
+    const mine = rows.filter((r) => r.accountId === cardId);
+
+    expect(mine).toHaveLength(1);
+    expect(mine[0].date).toBe("2020-06-30");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getDebtServiceSummary
+// ────────────────────────────────────────────────────────────────────
+
+describe("getDebtServiceSummary", () => {
+  it("aggregates payments and interest from every pinned category ID", async () => {
+    const cardId = await createAccount("Service Card", TYPE_CREDIT_CARD);
+    const mortgageId = await createAccount("Service Mortgage", TYPE_MORTGAGE);
+
+    // One $100 payment in every payment category, on a liability account.
+    for (const catId of DEBT_PAYMENT_CATEGORY_IDS) {
+      await insertTx(cardId, "2020-06-01", "100.00", catId);
+    }
+    // One $50 interest accrual in every interest category, on a liability account.
+    for (const catId of DEBT_INTEREST_CATEGORY_IDS) {
+      await insertTx(mortgageId, "2020-06-15", "-50.00", catId);
+    }
+    // A non-debt-service category on a liability account — must be excluded.
+    await insertTx(cardId, "2020-06-20", "-25.00", 6); // 'Other'
+
+    const result = await getDebtServiceSummary(PERF_START, PERF_END);
+
+    expect(result.totalPayments).toBeCloseTo(
+      100 * DEBT_PAYMENT_CATEGORY_IDS.length,
+      2
+    );
+    expect(result.interestAccrued).toBeCloseTo(
+      -50 * DEBT_INTEREST_CATEGORY_IDS.length,
+      2
+    );
+    expect(result.principalPaid).toBeCloseTo(
+      result.totalPayments + result.interestAccrued,
+      2
+    );
+  });
+
+  it("ignores transactions on non-liability accounts", async () => {
+    const checkingId = await createAccount("Service Checking", TYPE_CHECKING);
+    // Cat 12 (Mortgage Principle) is in DEBT_PAYMENT_CATEGORY_IDS — but
+    // posting it to a checking account should still be filtered out by
+    // the account_type_category_id IN (5,6) clause.
+    await insertTx(checkingId, "2020-06-01", "100.00", 12);
+    await insertTx(checkingId, "2020-06-10", "50.00", 51); // Interest Earned
+
+    const result = await getDebtServiceSummary(PERF_START, PERF_END);
+
+    expect(findDebtServiceAccount(result, checkingId)).toBeUndefined();
+  });
+
+  it("groups results by category > account type > account in the sub-table", async () => {
+    const cardId = await createAccount("ByAcct Card", TYPE_CREDIT_CARD);
+    const mortgageId = await createAccount("ByAcct Mortgage", TYPE_MORTGAGE);
+    // Credit-card paydowns post to the liability account as Applied Credit (29).
+    await insertTx(cardId, "2020-06-01", "200.00", 29);
+    // Mortgage payments split into principal (12) + interest paid (13) on
+    // the liability side. Accrued interest (14) is the offsetting accrual.
+    await insertTx(mortgageId, "2020-06-05", "700.00", 12);
+    await insertTx(mortgageId, "2020-06-05", "800.00", 13);
+    await insertTx(mortgageId, "2020-06-15", "-800.00", 14);
+
+    const result = await getDebtServiceSummary(PERF_START, PERF_END);
+
+    const byCard = findDebtServiceAccount(result, cardId);
+    const byMortgage = findDebtServiceAccount(result, mortgageId);
+    expect(byCard?.totalPayments).toBeCloseTo(200, 2);
+    expect(byCard?.interestAccrued).toBeCloseTo(0, 2);
+    // Total payment to servicer = principal + interest paid.
+    expect(byMortgage?.totalPayments).toBeCloseTo(1500, 2);
+    expect(byMortgage?.interestAccrued).toBeCloseTo(-800, 2);
+    // Net principal paid = total payments + (negative) accrual = 700.
+    expect(byMortgage?.principalPaid).toBeCloseTo(700, 2);
+
+    // Hierarchy parents = sum of children at each level.
+    for (const cat of result.categories) {
+      const typeSum = cat.accountTypes.reduce(
+        (s, t) => s + t.totalPayments,
+        0
+      );
+      expect(typeSum).toBeCloseTo(cat.totalPayments, 2);
+      for (const type of cat.accountTypes) {
+        const acctSum = type.accounts.reduce(
+          (s, a) => s + a.totalPayments,
+          0
+        );
+        expect(acctSum).toBeCloseTo(type.totalPayments, 2);
+      }
+    }
+
+    // Card lands under Current Liabilities (5); Mortgage under Non-current (6).
+    const currentCat = result.categories.find((c) => c.categoryId === 5);
+    const nonCurrentCat = result.categories.find((c) => c.categoryId === 6);
+    expect(
+      currentCat?.accountTypes
+        .flatMap((t) => t.accounts)
+        .some((a) => a.accountId === cardId)
+    ).toBe(true);
+    expect(
+      nonCurrentCat?.accountTypes
+        .flatMap((t) => t.accounts)
+        .some((a) => a.accountId === mortgageId)
+    ).toBe(true);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getDebtWaterfall
+// ────────────────────────────────────────────────────────────────────
+
+describe("getDebtWaterfall", () => {
+  it("reconciles: start + payments + interest + other = end", async () => {
+    const mortgageId = await createAccount("WF Mortgage", TYPE_MORTGAGE);
+
+    await insertBalance(mortgageId, PERF_START, "-100000.00");
+    await insertBalance(mortgageId, PERF_END, "-95000.00");
+
+    // Liability-side payment legs: principal (12) + interest paid (13).
+    await insertTx(mortgageId, "2020-03-01", "5000.00", 12); // Mortgage Principle
+    await insertTx(mortgageId, "2020-03-01", "1000.00", 13); // Mortgage Interest
+    await insertTx(mortgageId, "2020-06-01", "-1000.00", 14); // Accrued Mortgage Interest
+
+    const result = await getDebtWaterfall(PERF_START, PERF_END);
+
+    expect(result.startBalance).toBeCloseTo(-100000, 2);
+    expect(result.endBalance).toBeCloseTo(-95000, 2);
+    expect(result.payments).toBeCloseTo(6000, 2);
+    expect(result.interestAccrued).toBeCloseTo(-1000, 2);
+
+    // Bridge reconciles exactly — `other` closes the gap.
+    const reconciled =
+      result.startBalance +
+      result.payments +
+      result.interestAccrued +
+      result.other;
+    expect(reconciled).toBeCloseTo(result.endBalance, 2);
+  });
+
+  it("returns zeros when there is no liability activity in the range", async () => {
+    const result = await getDebtWaterfall("1999-01-01", "1999-12-31");
+    expect(result.startBalance).toBe(0);
+    expect(result.endBalance).toBe(0);
+    expect(result.payments).toBe(0);
+    expect(result.interestAccrued).toBe(0);
+    expect(result.other).toBe(0);
+  });
+});

--- a/app/tests/integration/vitest-setup.ts
+++ b/app/tests/integration/vitest-setup.ts
@@ -84,8 +84,30 @@ beforeAll(async () => {
   await db.execute(sql`
     INSERT INTO transaction_categories (transaction_category_id, transaction_category)
     OVERRIDING SYSTEM VALUE VALUES
-      (1, 'Credit Card Payment'),
-      (6, 'Other')
+      (1,  'Credit Card Payment'),
+      (2,  'HELOC Payment'),
+      (3,  'Mortgage Payment'),
+      (4,  'Student Loan Payment'),
+      (6,  'Other'),
+      (7,  'HELOC Principle'),
+      (8,  'HELOC Interest'),
+      (9,  'Accrued HELOC Interest'),
+      (12, 'Mortgage Principle'),
+      (13, 'Mortgage Interest'),
+      (14, 'Accrued Mortgage Interest'),
+      (29, 'Applied Credit'),
+      (51, 'Interest Earned'),
+      (54, 'Car Loan Payment'),
+      (57, 'Epic Loan Interest'),
+      (58, 'Epic Loan Payment'),
+      (68, 'Auto Loan Interest'),
+      (69, 'Accrued Auto Loan Interest'),
+      (70, 'Auto Loan Principle'),
+      (74, 'Accrued Student Loan Interest'),
+      (75, 'Student Loan Principle'),
+      (76, 'Student Loan Interest'),
+      (79, 'Balance Transfer Payment Expense'),
+      (80, 'Credit Card Interest')
     ON CONFLICT (transaction_category_id) DO UPDATE
       SET transaction_category = EXCLUDED.transaction_category
   `);

--- a/app/tests/unit/components/debt-mix-breakdown.test.ts
+++ b/app/tests/unit/components/debt-mix-breakdown.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { buildDebtMixTiles } from "@/components/dashboard/debt-mix-breakdown";
+import type { LiabilityAllocationData } from "@/lib/queries/liabilities-drilldown";
+
+const makeData = (
+  byCategory: LiabilityAllocationData["byCategory"],
+  totalLiabilities: number
+): LiabilityAllocationData => ({
+  totalLiabilities,
+  currentLiabilities: 0,
+  nonCurrentLiabilities: 0,
+  asOf: "2026-05-02",
+  byCategory,
+});
+
+describe("buildDebtMixTiles", () => {
+  it("flattens category tree into one tile per non-zero account type", () => {
+    const data = makeData(
+      [
+        {
+          categoryId: 5,
+          categoryName: "Current Liability",
+          value: -1000,
+          percentOfTotal: 25,
+          children: [
+            {
+              accountTypeId: 15,
+              accountTypeName: "Credit Card",
+              value: -1000,
+              percentOfParent: 100,
+              percentOfTotal: 25,
+            },
+          ],
+        },
+        {
+          categoryId: 6,
+          categoryName: "Non-current Liability",
+          value: -3000,
+          percentOfTotal: 75,
+          children: [
+            {
+              accountTypeId: 17,
+              accountTypeName: "Mortgage",
+              value: -2000,
+              percentOfParent: 66.67,
+              percentOfTotal: 50,
+            },
+            {
+              accountTypeId: 19,
+              accountTypeName: "Auto Loan",
+              value: -1000,
+              percentOfParent: 33.33,
+              percentOfTotal: 25,
+            },
+          ],
+        },
+      ],
+      -4000
+    );
+
+    const tiles = buildDebtMixTiles(data);
+
+    expect(tiles).toHaveLength(3);
+    // Largest magnitude first.
+    expect(tiles[0].accountTypeName).toBe("Mortgage");
+    expect(tiles[1].percent).toBe(25);
+    expect(tiles[2].percent).toBe(25);
+  });
+
+  it("excludes account types with a zero balance", () => {
+    const data = makeData(
+      [
+        {
+          categoryId: 5,
+          categoryName: "Current Liability",
+          value: -100,
+          percentOfTotal: 100,
+          children: [
+            {
+              accountTypeId: 15,
+              accountTypeName: "Credit Card",
+              value: -100,
+              percentOfParent: 100,
+              percentOfTotal: 100,
+            },
+            {
+              accountTypeId: 16,
+              accountTypeName: "Short-term Loan",
+              value: 0,
+              percentOfParent: 0,
+              percentOfTotal: 0,
+            },
+          ],
+        },
+      ],
+      -100
+    );
+
+    const tiles = buildDebtMixTiles(data);
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0].accountTypeName).toBe("Credit Card");
+  });
+
+  it("returns an empty list when there are no liabilities", () => {
+    const data = makeData([], 0);
+    expect(buildDebtMixTiles(data)).toHaveLength(0);
+  });
+
+  it("assigns deterministic colors per accountTypeId", () => {
+    const data = makeData(
+      [
+        {
+          categoryId: 5,
+          categoryName: "Current Liability",
+          value: -100,
+          percentOfTotal: 100,
+          children: [
+            {
+              accountTypeId: 15,
+              accountTypeName: "Credit Card",
+              value: -100,
+              percentOfParent: 100,
+              percentOfTotal: 100,
+            },
+          ],
+        },
+      ],
+      -100
+    );
+
+    const tilesA = buildDebtMixTiles(data);
+    const tilesB = buildDebtMixTiles(data);
+    expect(tilesA[0].color).toBe(tilesB[0].color);
+  });
+});

--- a/app/tests/unit/components/debt-waterfall-data-transform.test.ts
+++ b/app/tests/unit/components/debt-waterfall-data-transform.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { buildDebtWaterfallBars } from "@/components/charts/debt-waterfall-chart";
+import type { DebtWaterfallData } from "@/lib/queries/liabilities-drilldown";
+
+describe("buildDebtWaterfallBars", () => {
+  it("produces start, payments, interest, end bars (other dropped when zero)", () => {
+    const data: DebtWaterfallData = {
+      startBalance: -10000,
+      endBalance: -8800, // start + payments(2000) + interest(-800) + other(0)
+      payments: 2000,
+      interestAccrued: -800,
+      other: 0,
+    };
+    const bars = buildDebtWaterfallBars(data);
+    const names = bars.map((b) => b.name);
+    expect(names).toEqual(["Start", "Payments", "Interest", "End"]);
+  });
+
+  it("skips zero-delta change bars but keeps start/end", () => {
+    const data: DebtWaterfallData = {
+      startBalance: -5000,
+      endBalance: -5000,
+      payments: 0,
+      interestAccrued: 0,
+      other: 0,
+    };
+    const bars = buildDebtWaterfallBars(data);
+    expect(bars.map((b) => b.name)).toEqual(["Start", "End"]);
+  });
+
+  it("colors payments as 'good' (paydown) and interest as 'bad' (added debt)", () => {
+    const data: DebtWaterfallData = {
+      startBalance: -10000,
+      endBalance: -9000,
+      payments: 1500,
+      interestAccrued: -500,
+      other: 0,
+    };
+    const bars = buildDebtWaterfallBars(data);
+    const payments = bars.find((b) => b.name === "Payments");
+    const interest = bars.find((b) => b.name === "Interest");
+    expect(payments?.type).toBe("good");
+    expect(interest?.type).toBe("bad");
+  });
+
+  it("colors 'other' by sign — positive = good, negative = bad", () => {
+    const positiveOther: DebtWaterfallData = {
+      startBalance: -10000,
+      endBalance: -9500,
+      payments: 0,
+      interestAccrued: 0,
+      other: 500,
+    };
+    const negativeOther: DebtWaterfallData = {
+      startBalance: -10000,
+      endBalance: -10500,
+      payments: 0,
+      interestAccrued: 0,
+      other: -500,
+    };
+    expect(
+      buildDebtWaterfallBars(positiveOther).find((b) => b.name === "Other")
+        ?.type
+    ).toBe("good");
+    expect(
+      buildDebtWaterfallBars(negativeOther).find((b) => b.name === "Other")
+        ?.type
+    ).toBe("bad");
+  });
+
+  it("reconciles the bridge: running total + change-bar deltas = end balance", () => {
+    const data: DebtWaterfallData = {
+      startBalance: -12000,
+      endBalance: -10300, // start + 2400 - 500 - 200
+      payments: 2400,
+      interestAccrued: -500,
+      other: -200,
+    };
+    const bars = buildDebtWaterfallBars(data);
+    const startBar = bars.find((b) => b.name === "Start")!;
+    const endBar = bars.find((b) => b.name === "End")!;
+    // displayValue carries the signed value; sum of deltas + start = end.
+    const deltaSum = bars
+      .filter((b) => b.type === "good" || b.type === "bad")
+      .reduce((s, b) => s + b.displayValue, 0);
+    expect(startBar.displayValue + deltaSum).toBe(endBar.displayValue);
+  });
+
+  it("renders bars with non-negative `value` magnitudes (Recharts requires ≥ 0)", () => {
+    const data: DebtWaterfallData = {
+      startBalance: -8000,
+      endBalance: -7500,
+      payments: 700,
+      interestAccrued: -200,
+      other: 0,
+    };
+    for (const bar of buildDebtWaterfallBars(data)) {
+      expect(bar.value).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/app/tests/unit/components/liability-performance-table.test.ts
+++ b/app/tests/unit/components/liability-performance-table.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { formatPercentChange } from "@/components/dashboard/liability-performance-table";
+
+describe("formatPercentChange", () => {
+  it("renders an em-dash when start balance was zero (null input)", () => {
+    expect(formatPercentChange(null)).toBe("—");
+  });
+
+  it("delegates to signedPercent for finite values", () => {
+    expect(formatPercentChange(12.34)).toBe("+12.34%");
+    expect(formatPercentChange(-5)).toBe("-5.00%");
+    expect(formatPercentChange(0)).toBe("0.00%");
+  });
+});

--- a/app/tests/unit/lib/format/financial.test.ts
+++ b/app/tests/unit/lib/format/financial.test.ts
@@ -3,7 +3,7 @@ import {
   signedCurrency,
   signedPercent,
   changeColor,
-} from "@/components/dashboard/asset-performance-table";
+} from "@/lib/format/financial";
 
 describe("signedCurrency", () => {
   it("prefixes positive values with '+'", () => {

--- a/app/tests/unit/lib/queries/liability-categories.test.ts
+++ b/app/tests/unit/lib/queries/liability-categories.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEBT_INTEREST_CATEGORY_IDS,
+  DEBT_PAYMENT_CATEGORY_IDS,
+  LIABILITY_CATEGORY_IDS,
+  LIABILITY_CURRENT_CATEGORY_ID,
+  LIABILITY_NON_CURRENT_CATEGORY_ID,
+} from "@/lib/queries/liability-categories";
+
+describe("LIABILITY_CATEGORY_IDS", () => {
+  it("contains exactly the two liability category IDs from shared-lookups", () => {
+    expect(LIABILITY_CURRENT_CATEGORY_ID).toBe(5);
+    expect(LIABILITY_NON_CURRENT_CATEGORY_ID).toBe(6);
+    expect([...LIABILITY_CATEGORY_IDS].sort()).toEqual([5, 6]);
+  });
+});
+
+describe("DEBT_PAYMENT_CATEGORY_IDS", () => {
+  it("is non-empty and contains only positive integers", () => {
+    expect(DEBT_PAYMENT_CATEGORY_IDS.length).toBeGreaterThan(0);
+    for (const id of DEBT_PAYMENT_CATEGORY_IDS) {
+      expect(Number.isInteger(id)).toBe(true);
+      expect(id).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicates", () => {
+    const set = new Set(DEBT_PAYMENT_CATEGORY_IDS);
+    expect(set.size).toBe(DEBT_PAYMENT_CATEGORY_IDS.length);
+  });
+});
+
+describe("DEBT_INTEREST_CATEGORY_IDS", () => {
+  it("is non-empty and contains only positive integers", () => {
+    expect(DEBT_INTEREST_CATEGORY_IDS.length).toBeGreaterThan(0);
+    for (const id of DEBT_INTEREST_CATEGORY_IDS) {
+      expect(Number.isInteger(id)).toBe(true);
+      expect(id).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicates", () => {
+    const set = new Set(DEBT_INTEREST_CATEGORY_IDS);
+    expect(set.size).toBe(DEBT_INTEREST_CATEGORY_IDS.length);
+  });
+
+  it("does not overlap with payment IDs (would double-count)", () => {
+    const paymentSet = new Set<number>(DEBT_PAYMENT_CATEGORY_IDS);
+    for (const id of DEBT_INTEREST_CATEGORY_IDS) {
+      expect(paymentSet.has(id)).toBe(false);
+    }
+  });
+});

--- a/init-db/seeds/finances-test-mock-data.sql
+++ b/init-db/seeds/finances-test-mock-data.sql
@@ -41,7 +41,13 @@ OVERRIDING SYSTEM VALUE VALUES
 ON CONFLICT (account_type_id) DO NOTHING;
 
 -- --------------------------------------------
--- 2. transaction_categories (27 rows; IDs match production seed)
+-- 2. transaction_categories (IDs match production seed)
+--
+-- Liabilities-drilldown queries pin specific category IDs for payments and
+-- interest expense (see app/lib/queries/liability-categories.ts). All of
+-- the relevant rows must be present here so integration tests exercise the
+-- full set; the production seed contains additional categories not used by
+-- this test fixture.
 -- --------------------------------------------
 INSERT INTO transaction_categories (transaction_category_id, transaction_category)
 OVERRIDING SYSTEM VALUE VALUES
@@ -51,7 +57,11 @@ OVERRIDING SYSTEM VALUE VALUES
     (4,  'Student Loan Payment'),
     (5,  'Cash / Crypto Deposit'),
     (6,  'Other'),
+    (9,  'Accrued HELOC Interest'),
     (10, 'Cash / Crypto Withdrawal'),
+    (12, 'Mortgage Principle'),
+    (13, 'Mortgage Interest'),
+    (14, 'Accrued Mortgage Interest'),
     (15, 'Labor Earnings'),
     (21, 'Withdrawal to Savings'),
     (22, 'Medicare Tax'),
@@ -59,6 +69,7 @@ OVERRIDING SYSTEM VALUE VALUES
     (24, 'Food / Grocery'),
     (25, 'Social Security Tax'),
     (26, 'State Income Tax'),
+    (29, 'Applied Credit'),
     (33, 'Restaurant'),
     (34, 'Entertainment'),
     (36, 'Subscription'),
@@ -68,10 +79,18 @@ OVERRIDING SYSTEM VALUE VALUES
     (51, 'Interest Earned'),
     (54, 'Car Loan Payment'),
     (55, 'Water Utility'),
+    (57, 'Epic Loan Interest'),
+    (58, 'Epic Loan Payment'),
     (60, 'Gas & Electric Utility'),
     (62, 'Car & Personal Articles Insurance'),
     (63, 'Internet Service Provider'),
-    (64, 'Mobile Service Provider')
+    (64, 'Mobile Service Provider'),
+    (68, 'Auto Loan Interest'),
+    (69, 'Accrued Auto Loan Interest'),
+    (70, 'Auto Loan Principle'),
+    (74, 'Accrued Student Loan Interest'),
+    (79, 'Balance Transfer Payment Expense'),
+    (80, 'Credit Card Interest')
 ON CONFLICT (transaction_category_id) DO NOTHING;
 
 -- --------------------------------------------
@@ -134,7 +153,11 @@ BEGIN
     FROM generate_series(0, 25) n
     WHERE (opening_date + INTERVAL '1 day' + (n * INTERVAL '14 days'))::date <= CURRENT_DATE;
 
-    -- ---- Monthly mortgage payments (12 pairs = 24 rows) ----
+    -- ---- Monthly mortgage payments ----
+    -- Cash side: one debit on checking, category 3 (Mortgage Payment).
+    -- Liability side: split into principal (cat 12) + interest (cat 13)
+    -- so the totals match production conventions where each loan payment
+    -- posts to the liability account as two legs.
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
     SELECT 'Mortgage Payment', (month0 + (n * INTERVAL '1 month') + INTERVAL '9 days')::date,
            1, -2100.00, 4, 1, 3
@@ -142,15 +165,23 @@ BEGIN
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '9 days')::date <= CURRENT_DATE;
 
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
-    SELECT 'Mortgage Payment', (month0 + (n * INTERVAL '1 month') + INTERVAL '9 days')::date,
-           4, 2100.00, 1, 1, 3
+    SELECT 'Mortgage Principle', (month0 + (n * INTERVAL '1 month') + INTERVAL '9 days')::date,
+           4, 900.00, 1, 1, 12
+    FROM generate_series(0, 11) n
+    WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '9 days')::date <= CURRENT_DATE;
+
+    INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
+    SELECT 'Mortgage Interest', (month0 + (n * INTERVAL '1 month') + INTERVAL '9 days')::date,
+           4, 1200.00, 1, 1, 13
     FROM generate_series(0, 11) n
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '9 days')::date <= CURRENT_DATE;
 
     -- ---- Monthly mortgage interest accruals (12) ----
+    -- Category 14 (Accrued Mortgage Interest) is one of the IDs the
+    -- Liabilities-drilldown debt-service queries pin. Keep this row aligned.
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
     SELECT 'Mortgage Interest Accrual', (month0 + (n * INTERVAL '1 month') + INTERVAL '14 days')::date,
-           4, -1200.00, NULL, 9, 6
+           4, -1200.00, NULL, 9, 14
     FROM generate_series(0, 11) n
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '14 days')::date <= CURRENT_DATE;
 
@@ -187,6 +218,8 @@ BEGIN
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '21 days')::date <= CURRENT_DATE;
 
     -- ---- Monthly credit card payment (12 pairs = 24 rows) ----
+    -- Cash side: cat 1 (Credit Card Payment). Liability side: cat 29
+    -- (Applied Credit) — production convention for credit-card paydowns.
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
     SELECT 'Payment to Visa', (month0 + (n * INTERVAL '1 month') + INTERVAL '5 days')::date,
            1, -450.00, 3, 1, 1
@@ -195,11 +228,13 @@ BEGIN
 
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
     SELECT 'Payment from Checking', (month0 + (n * INTERVAL '1 month') + INTERVAL '5 days')::date,
-           3, 450.00, 1, 1, 1
+           3, 450.00, 1, 1, 29
     FROM generate_series(0, 11) n
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '5 days')::date <= CURRENT_DATE;
 
-    -- ---- Monthly auto loan payment (12 pairs = 24 rows) ----
+    -- ---- Monthly auto loan payment ----
+    -- Cash side: cat 54 (Car Loan Payment). Liability side splits into
+    -- principal (cat 70) + interest (cat 68).
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
     SELECT 'Auto Loan Payment', (month0 + (n * INTERVAL '1 month') + INTERVAL '7 days')::date,
            1, -385.00, 5, 1, 54
@@ -207,15 +242,23 @@ BEGIN
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '7 days')::date <= CURRENT_DATE;
 
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
-    SELECT 'Auto Loan Payment', (month0 + (n * INTERVAL '1 month') + INTERVAL '7 days')::date,
-           5, 385.00, 1, 1, 54
+    SELECT 'Auto Loan Principle', (month0 + (n * INTERVAL '1 month') + INTERVAL '7 days')::date,
+           5, 265.00, 1, 1, 70
+    FROM generate_series(0, 11) n
+    WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '7 days')::date <= CURRENT_DATE;
+
+    INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
+    SELECT 'Auto Loan Interest', (month0 + (n * INTERVAL '1 month') + INTERVAL '7 days')::date,
+           5, 120.00, 1, 1, 68
     FROM generate_series(0, 11) n
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '7 days')::date <= CURRENT_DATE;
 
     -- ---- Monthly auto loan interest accrual (12) ----
+    -- Category 69 (Accrued Auto Loan Interest) is one of the IDs the
+    -- Liabilities-drilldown debt-service queries pin. Keep this row aligned.
     INSERT INTO transactions (transaction_description, transaction_date, account_id, amount, related_account_id, transaction_type_id, transaction_category_id)
     SELECT 'Auto Loan Interest Accrual', (month0 + (n * INTERVAL '1 month') + INTERVAL '14 days')::date,
-           5, -120.00, NULL, 9, 6
+           5, -120.00, NULL, 9, 69
     FROM generate_series(0, 11) n
     WHERE (month0 + (n * INTERVAL '1 month') + INTERVAL '14 days')::date <= CURRENT_DATE;
 


### PR DESCRIPTION
## Summary
- New `/dashboard/liabilities` drilldown mirroring the Assets page: KPI strip, allocation treemap, stacked time-series decomposition, debt-mix tile breakdown, debt waterfall (Start → Payments → Interest → Other → End), debt-service summary, and a 3-level expandable Liability Performance table. Sign convention: liability balances stay negative throughout; paydowns render green, added debt red.
- Lookup-driven design: only `account_type_category_id` (5/6) is hard-coded in queries. Pinned `transaction_category_id`s for debt payments and interest expense live in `app/lib/queries/liability-categories.ts` (no name-pattern matching, no `transaction_type_id` reference). Test seed and `vitest-setup.ts` carry the full pinned set so integration coverage doesn't drift.
- Fix: Credit Card Interest (cat 80) was classified as a payment, so finance-charge rows summed into Total Payments instead of Interest Accrued and never showed up where the user expected. Moved 80 into `DEBT_INTEREST_CATEGORY_IDS` (it adds to the balance, like the `Accrued *` loan categories) and corrected the doc comment.
- Added "% of Payment" columns next to Interest and Principal in the Debt Service summary at every level (category / type / account / total), with a `—` fallback when payments are zero.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` (unit + integration) passes against `Finances_Test`
- [x] Open `/dashboard/liabilities` and verify all sections render: KPIs, treemap, time-series, debt mix, waterfall, debt service, performance table
- [x] Expand the Debt Service table at every level — confirm Interest and Principal % of Payment columns render and sum to 100% per row
- [x] Confirm a Credit Card Interest transaction on a credit-card account shows up in the Interest Accrued column (not Total Payments) and that `Principal Paid = Total Payments + (negative) Interest Accrued` reconciles
- [x] Spot-check an account with zero payments in-period — `% of Payment` cells render `—` not `NaN%`
- [x] Date-range filter / period switcher behaves the same as on the Assets page

🤖 Generated with [Claude Code](https://claude.com/claude-code)