### PR TITLE
Issue #114 - Date Range filter UX fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ finance-stack/
 │   │   ├── queries/liability-categories.ts # Pinned transaction_category_ids for debt payments and interest expense
 │   │   ├── queries/rebuild-balance.ts    # Per-account balance history rebuild
 │   │   ├── queries/transactions.ts       # Transaction queries (filtered, sorted, form options)
+│   │   ├── queries/date-range.ts         # Shared dateFrom/dateTo URL-param parsing + 30-day default
 │   │   ├── queries/categories.ts         # Queries for all four reference-data tables
 │   │   ├── format/financial.ts           # Shared signed-currency, change-color, percent helpers (used by asset + liability tables)
 │   │   ├── forms/transaction.ts          # Post-submit state helper (persists Date, Account, Type across submits)
@@ -375,7 +376,16 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
 
-### 2026-05-02 — v0.1.2 (in progress)
+### 2026-05-10 — v0.1.3 (in progress)
+
+**Date Range filter UX fixes (related to Issue #61)**
+- Picker now uses a draft-and-commit pattern: calendar clicks and typed input update local state inside the popover, and the URL is only updated when the user clicks **Apply** (or selects a Quick Select preset). Fixes the "popover closes after one click" and "phantom from-date already selected" bugs caused by passing the 30-day default through to the picker as a real selection.
+- Manual date input fields are now plain text inputs (`YYYY-MM-DD`) bound to local draft string state, instead of native `<input type="date">` controlled inputs. Typing now works as expected (e.g. `12` in the month no longer snaps to `02`), and clicking the field no longer pops the browser's native date picker on top of the custom calendar.
+- Added explicit **Apply** and **Clear** buttons in the popover footer; cancellation (click-outside / Esc) discards the draft.
+- Extracted the duplicated `defaultFrom = today − 30 days` block from 8 files into a single shared helper `app/lib/queries/date-range.ts` (`getDateRangeFromParams`). The 30-day default now lives only in the data-fetching layer; the picker UI shows `Last 30 days (default)` as placeholder text in the trigger when no URL params are set.
+- No change to Quick Select macros, calendar styling, or the URL-param contract (`?dateFrom=YYYY-MM-DD&dateTo=YYYY-MM-DD`). [Issue #61](https://github.com/aellington89/finance-stack/issues/61) (saveable Quick Select presets) remains a follow-up.
+
+### 2026-05-02 — v0.1.2
 
 **Liabilities drilldown page (Issue #112)**
 - New page at `/dashboard/liabilities` mirrors the Assets drilldown structure with sections specific to debt: a 4-card KPI strip (Total / Current / Long-term liabilities, Period Change), liability allocation treemap (category → account type), stacked time-series decomposition by category, dynamic per-account-type Debt Mix tile breakdown, Debt Waterfall (Start → Payments → Interest → Other → End), Debt Service summary (period payments, interest accrued, estimated principal paid + per-account sub-table), and a 3-level expandable Liability Performance table.

--- a/app/app/(app)/dashboard/accounting/page.tsx
+++ b/app/app/(app)/dashboard/accounting/page.tsx
@@ -16,6 +16,7 @@ import { AccountingChart } from "@/components/charts/accounting-chart";
 import { ExpensesCategoryChart } from "@/components/charts/expenses-category-chart";
 import { AccountingKpiCard } from "@/components/dashboard/accounting-kpi-card";
 import { AccountingFilters as AccountingFiltersUI } from "@/components/dashboard/accounting-filters";
+import { getDateRangeFromParams } from "@/lib/queries/date-range";
 
 export const dynamic = "force-dynamic";
 
@@ -161,13 +162,7 @@ function parseSearchParams(
     return items.length > 0 ? items : undefined;
   };
 
-  // Default to last 30 days
-  const defaultFrom = new Date();
-  defaultFrom.setDate(defaultFrom.getDate() - 30);
-  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
-
-  const dateFrom = get("dateFrom") || defaultFromStr;
-  const dateTo = get("dateTo") || undefined;
+  const { dateFrom, dateTo } = getDateRangeFromParams(params);
   const descriptions = getStringArray("descriptions");
   const accountIds = getNumberArray("accountIds");
   const categoryIds = getNumberArray("categoryIds");

--- a/app/app/(app)/dashboard/assets/page.tsx
+++ b/app/app/(app)/dashboard/assets/page.tsx
@@ -10,6 +10,7 @@ import { AssetPerformanceTable } from "@/components/dashboard/asset-performance-
 import { LiquidityBreakdown } from "@/components/dashboard/liquidity-breakdown";
 import { SummaryDrilldownTabs } from "@/components/dashboard/summary-drilldown-tabs";
 import { DashboardDateRangeFilter } from "@/components/dashboard/date-range-filter";
+import { getDateRangeFromParams } from "@/lib/queries/date-range";
 import {
   Card,
   CardContent,
@@ -32,17 +33,7 @@ export default async function AssetsDrilldownPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const params = await searchParams;
-
-  const defaultFrom = new Date();
-  defaultFrom.setDate(defaultFrom.getDate() - 30);
-  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
-
-  const dateFrom =
-    (Array.isArray(params.dateFrom) ? params.dateFrom[0] : params.dateFrom) ||
-    defaultFromStr;
-  const dateTo =
-    (Array.isArray(params.dateTo) ? params.dateTo[0] : params.dateTo) ||
-    undefined;
+  const { dateFrom, dateTo } = getDateRangeFromParams(params);
 
   const [allocation, performance, liquidity, decomposition] = await Promise.all(
     [

--- a/app/app/(app)/dashboard/liabilities/page.tsx
+++ b/app/app/(app)/dashboard/liabilities/page.tsx
@@ -13,6 +13,7 @@ import { DebtServiceSummary } from "@/components/dashboard/debt-service-summary"
 import { LiabilityPerformanceTable } from "@/components/dashboard/liability-performance-table";
 import { SummaryDrilldownTabs } from "@/components/dashboard/summary-drilldown-tabs";
 import { DashboardDateRangeFilter } from "@/components/dashboard/date-range-filter";
+import { getDateRangeFromParams } from "@/lib/queries/date-range";
 import {
   Card,
   CardContent,
@@ -36,17 +37,7 @@ export default async function LiabilitiesDrilldownPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const params = await searchParams;
-
-  const defaultFrom = new Date();
-  defaultFrom.setDate(defaultFrom.getDate() - 30);
-  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
-
-  const dateFrom =
-    (Array.isArray(params.dateFrom) ? params.dateFrom[0] : params.dateFrom) ||
-    defaultFromStr;
-  const dateTo =
-    (Array.isArray(params.dateTo) ? params.dateTo[0] : params.dateTo) ||
-    undefined;
+  const { dateFrom, dateTo } = getDateRangeFromParams(params);
 
   const [allocation, performance, decomposition, debtService, waterfall] =
     await Promise.all([

--- a/app/app/(app)/dashboard/net-worth/page.tsx
+++ b/app/app/(app)/dashboard/net-worth/page.tsx
@@ -12,6 +12,7 @@ import { WaterfallChart } from "@/components/charts/waterfall-chart";
 import { NetWorthDriversTable } from "@/components/dashboard/net-worth-drivers-table";
 import { SummaryDrilldownTabs } from "@/components/dashboard/summary-drilldown-tabs";
 import { DashboardDateRangeFilter } from "@/components/dashboard/date-range-filter";
+import { getDateRangeFromParams } from "@/lib/queries/date-range";
 import {
   Card,
   CardContent,
@@ -34,18 +35,7 @@ export default async function NetWorthDrilldownPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const params = await searchParams;
-
-  // Default to last 30 days when no date range is specified
-  const defaultFrom = new Date();
-  defaultFrom.setDate(defaultFrom.getDate() - 30);
-  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
-
-  const dateFrom =
-    (Array.isArray(params.dateFrom) ? params.dateFrom[0] : params.dateFrom) ||
-    defaultFromStr;
-  const dateTo =
-    (Array.isArray(params.dateTo) ? params.dateTo[0] : params.dateTo) ||
-    undefined;
+  const { dateFrom, dateTo } = getDateRangeFromParams(params);
 
   const [summary, timeSeries, waterfall, drivers, decomposition] =
     await Promise.all([

--- a/app/app/(app)/dashboard/page.tsx
+++ b/app/app/(app)/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { TimeSeriesChart } from "@/components/charts/net-worth-chart";
 import { GaugeBadge } from "@/components/charts/gauge-badge";
 import { SummaryDrilldownTabs } from "@/components/dashboard/summary-drilldown-tabs";
 import { DashboardDateRangeFilter } from "@/components/dashboard/date-range-filter";
+import { getDateRangeFromParams } from "@/lib/queries/date-range";
 import {
   Card,
   CardContent,
@@ -46,18 +47,7 @@ export default async function DashboardSummaryPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const params = await searchParams;
-
-  // Default to last 30 days when no date range is specified
-  const defaultFrom = new Date();
-  defaultFrom.setDate(defaultFrom.getDate() - 30);
-  const defaultFromStr = defaultFrom.toISOString().slice(0, 10);
-
-  const dateFrom =
-    (Array.isArray(params.dateFrom) ? params.dateFrom[0] : params.dateFrom) ||
-    defaultFromStr;
-  const dateTo =
-    (Array.isArray(params.dateTo) ? params.dateTo[0] : params.dateTo) ||
-    undefined;
+  const { dateFrom, dateTo } = getDateRangeFromParams(params);
 
   const [summary, timeSeries] = await Promise.all([
     getCurrentNetWorth(),

--- a/app/app/(app)/dashboard/transactions/page.tsx
+++ b/app/app/(app)/dashboard/transactions/page.tsx
@@ -7,6 +7,7 @@ import {
   type SortableColumn,
   type SortDirection,
 } from "@/lib/queries/transactions";
+import { getDateRangeFromParams } from "@/lib/queries/date-range";
 import { TransactionForm } from "@/components/transactions/transaction-form";
 import { TransactionFilters as TransactionFiltersUI } from "@/components/transactions/transaction-filters";
 import { TransactionList } from "@/components/transactions/transaction-list";
@@ -54,9 +55,13 @@ function parseSearchParams(
   const rawPage = get("page");
   const rawPageSize = get("pageSize");
 
+  const { dateFrom, dateTo } = getDateRangeFromParams(searchParams, {
+    applyDefault: false,
+  });
+
   return {
-    dateFrom: get("dateFrom"),
-    dateTo: get("dateTo"),
+    dateFrom,
+    dateTo,
     descriptions: getStringArray("descriptions"),
     amount: get("amount"),
     accountIds: getNumberArray("accountIds"),

--- a/app/app/(app)/dashboard/work-expenses/page.tsx
+++ b/app/app/(app)/dashboard/work-expenses/page.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/lib/queries/work-expenses";
 import { AccountingKpiCard } from "@/components/dashboard/accounting-kpi-card";
 import { DashboardDateRangeFilter } from "@/components/dashboard/date-range-filter";
+import { getDateRangeFromParams } from "@/lib/queries/date-range";
 import { WorkExpensesChart } from "@/components/charts/work-expenses-chart";
 import { ExpensesCategoryChart } from "@/components/charts/expenses-category-chart";
 
@@ -23,20 +24,7 @@ export default async function WorkExpensesPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const resolvedParams = await searchParams;
-
-  const get = (key: string): string | undefined => {
-    const val = resolvedParams[key];
-    if (Array.isArray(val)) return val[0];
-    return val || undefined;
-  };
-
-  // Default to last 30 days
-  const defaultFrom = new Date();
-  defaultFrom.setDate(defaultFrom.getDate() - 30);
-  const dateFrom = get("dateFrom") || defaultFrom.toISOString().slice(0, 10);
-  const dateTo = get("dateTo") || undefined;
-
-  const filters = { dateFrom, dateTo };
+  const filters = getDateRangeFromParams(resolvedParams);
 
   const [totals, timeSeries, categoryBreakdown] = await Promise.all([
     getWorkExpenseTotals(filters),

--- a/app/components/dashboard/accounting-filters.tsx
+++ b/app/components/dashboard/accounting-filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -210,12 +210,6 @@ export function AccountingFilters({
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const defaultFrom = useMemo(() => {
-    const d = new Date();
-    d.setDate(d.getDate() - 30);
-    return d.toISOString().slice(0, 10);
-  }, []);
-
   const updateParams = useCallback(
     (updates: Record<string, string | undefined>) => {
       const params = new URLSearchParams(searchParams.toString());
@@ -274,9 +268,10 @@ export function AccountingFilters({
     <div className="flex flex-wrap items-end gap-2">
       <FilterSlot label="Date" className="w-56">
         <DateRangePicker
-          dateFrom={filters.dateFrom ?? defaultFrom}
+          dateFrom={filters.dateFrom ?? undefined}
           dateTo={filters.dateTo ?? undefined}
           onChange={handleDateRange}
+          placeholder="Last 30 days (default)"
           className="h-8 text-xs"
         />
       </FilterSlot>

--- a/app/components/dashboard/date-range-filter.tsx
+++ b/app/components/dashboard/date-range-filter.tsx
@@ -1,19 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { DateRangePicker } from "@/components/ui/date-range-picker";
 
 export function DashboardDateRangeFilter({ basePath = "/dashboard" }: { basePath?: string } = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
-
-  // Default to last 30 days when no URL param is set
-  const defaultFrom = useMemo(() => {
-    const d = new Date();
-    d.setDate(d.getDate() - 30);
-    return d.toISOString().slice(0, 10);
-  }, []);
 
   const handleChange = (from: string | undefined, to: string | undefined) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -27,9 +19,10 @@ export function DashboardDateRangeFilter({ basePath = "/dashboard" }: { basePath
 
   return (
     <DateRangePicker
-      dateFrom={searchParams.get("dateFrom") ?? defaultFrom}
+      dateFrom={searchParams.get("dateFrom") ?? undefined}
       dateTo={searchParams.get("dateTo") ?? undefined}
       onChange={handleChange}
+      placeholder="Last 30 days (default)"
       className="w-[280px]"
     />
   );

--- a/app/components/ui/date-range-picker.tsx
+++ b/app/components/ui/date-range-picker.tsx
@@ -32,6 +32,7 @@ interface DateRangePickerProps {
   dateTo?: string
   onChange: (from: string | undefined, to: string | undefined) => void
   className?: string
+  placeholder?: string
 }
 
 type Scope = "last" | "this"
@@ -86,9 +87,12 @@ function formatDateStr(d: Date): string {
   return `${yyyy}-${mm}-${dd}`
 }
 
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
 function parseDate(s?: string): Date | undefined {
-  if (!s) return undefined
-  return new Date(s + "T00:00:00")
+  if (!s || !ISO_DATE_RE.test(s)) return undefined
+  const d = new Date(s + "T00:00:00")
+  return isNaN(d.getTime()) ? undefined : d
 }
 
 const SCOPES: { value: Scope; label: string }[] = [
@@ -171,70 +175,143 @@ function QuickSelect({
   )
 }
 
+interface Draft {
+  from: Date | undefined
+  to: Date | undefined
+  fromStr: string
+  toStr: string
+}
+
+function buildDraft(dateFrom?: string, dateTo?: string): Draft {
+  return {
+    from: parseDate(dateFrom),
+    to: parseDate(dateTo),
+    fromStr: dateFrom ?? "",
+    toStr: dateTo ?? "",
+  }
+}
+
 function DateRangePicker({
   dateFrom,
   dateTo,
   onChange,
   className,
+  placeholder = "Select dates...",
 }: DateRangePickerProps) {
   const [open, setOpen] = React.useState(false)
+  const [draft, setDraft] = React.useState<Draft>(() =>
+    buildDraft(dateFrom, dateTo)
+  )
 
-  const from = parseDate(dateFrom)
-  const to = parseDate(dateTo)
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      // Re-sync from props each time the popover opens; discards any
+      // uncommitted draft from a previously cancelled session.
+      setDraft(buildDraft(dateFrom, dateTo))
+    }
+    setOpen(next)
+  }
 
   const selected: DateRange | undefined =
-    from || to ? { from, to } : undefined
+    draft.from || draft.to ? { from: draft.from, to: draft.to } : undefined
 
   const handleQuickApply = (rangeFrom: Date, rangeTo: Date) => {
     onChange(formatDateStr(rangeFrom), formatDateStr(rangeTo))
     setOpen(false)
   }
 
-  const handleRangeSelect = (range: DateRange | undefined) => {
-    if (!range) {
-      onChange(undefined, undefined)
-      return
-    }
-    onChange(
-      range.from ? formatDateStr(range.from) : undefined,
-      range.to ? formatDateStr(range.to) : undefined
-    )
-    if (range.from && range.to) {
-      setOpen(false)
-    }
+  const handleRangeSelect = (
+    _range: DateRange | undefined,
+    triggerDate: Date
+  ) => {
+    // Track clicks manually using `triggerDate`. react-day-picker's own range
+    // computation has two annoying behaviors we override here:
+    //   1. Clicking inside a complete range shrinks it to the closer endpoint
+    //      instead of starting a fresh selection.
+    //   2. Clicking before an in-progress `from` swaps so the new click becomes
+    //      `from` — fine for that case, but combined with (1) it makes editing
+    //      an existing range feel unpredictable.
+    // Two-click model: 1st click sets `from`, 2nd click sets `to` (sorted for
+    // display). A 3rd click while complete restarts from that date.
+    setDraft((d) => {
+      if (!d.from || d.to) {
+        // No selection yet, or range already complete → start fresh
+        return {
+          from: triggerDate,
+          to: undefined,
+          fromStr: formatDateStr(triggerDate),
+          toStr: "",
+        }
+      }
+      // Only `from` is set → complete the range with this click
+      let from = d.from
+      let to = triggerDate
+      if (to < from) {
+        [from, to] = [to, from]
+      }
+      return {
+        from,
+        to,
+        fromStr: formatDateStr(from),
+        toStr: formatDateStr(to),
+      }
+    })
   }
 
   const handleManualDate = (which: "from" | "to", value: string) => {
-    if (!value) {
-      if (which === "from") onChange(undefined, dateTo)
-      else onChange(dateFrom, undefined)
-      return
+    const parsed = parseDate(value)
+    if (which === "from") {
+      setDraft((d) => ({ ...d, fromStr: value, from: parsed ?? d.from }))
+    } else {
+      setDraft((d) => ({ ...d, toStr: value, to: parsed ?? d.to }))
     }
-    // Validate YYYY-MM-DD format
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return
-    const d = new Date(value + "T00:00:00")
-    if (isNaN(d.getTime())) return
-    if (which === "from") onChange(value, dateTo)
-    else onChange(dateFrom, value)
   }
 
-  // Build display text
-  let displayText = "Select dates..."
-  if (from && to) {
-    displayText = `${format(from, "MMM d")} – ${format(to, "MMM d, yyyy")}`
-  } else if (from) {
-    displayText = `${format(from, "MMM d, yyyy")} – ...`
+  const handleApply = () => {
+    let fromStr = draft.fromStr.trim() || undefined
+    let toStr = draft.toStr.trim() || undefined
+
+    // Drop strings that don't parse — never silently commit garbage.
+    if (fromStr && !parseDate(fromStr)) fromStr = undefined
+    if (toStr && !parseDate(toStr)) toStr = undefined
+
+    if (fromStr && toStr && fromStr > toStr) {
+      [fromStr, toStr] = [toStr, fromStr]
+    }
+
+    onChange(fromStr, toStr)
+    setOpen(false)
   }
+
+  const handleClear = () => {
+    onChange(undefined, undefined)
+    setDraft({ from: undefined, to: undefined, fromStr: "", toStr: "" })
+    setOpen(false)
+  }
+
+  // Build trigger display text from committed props (not draft).
+  const triggerFrom = parseDate(dateFrom)
+  const triggerTo = parseDate(dateTo)
+  let displayText = placeholder
+  if (triggerFrom && triggerTo) {
+    displayText = `${format(triggerFrom, "MMM d")} – ${format(triggerTo, "MMM d, yyyy")}`
+  } else if (triggerFrom) {
+    displayText = `${format(triggerFrom, "MMM d, yyyy")} – ...`
+  } else if (triggerTo) {
+    displayText = `... – ${format(triggerTo, "MMM d, yyyy")}`
+  }
+
+  const isEmpty = !dateFrom && !dateTo
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger
         render={
           <Button
             variant="outline"
             className={cn(
               "w-full justify-start text-left font-normal",
-              !dateFrom && !dateTo && "text-muted-foreground",
+              isEmpty && "text-muted-foreground",
               className
             )}
           />
@@ -253,23 +330,45 @@ function DateRangePicker({
               mode="range"
               selected={selected}
               onSelect={handleRangeSelect}
-              defaultMonth={from || to}
+              defaultMonth={draft.from || draft.to}
               numberOfMonths={2}
             />
             <div className="flex items-center gap-2 border-t px-2 py-2">
               <Input
-                type="date"
-                value={dateFrom ?? ""}
+                type="text"
+                inputMode="numeric"
+                placeholder="YYYY-MM-DD"
+                value={draft.fromStr}
                 onChange={(e) => handleManualDate("from", e.target.value)}
                 className="h-7 flex-1 text-xs"
               />
               <ArrowRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
               <Input
-                type="date"
-                value={dateTo ?? ""}
+                type="text"
+                inputMode="numeric"
+                placeholder="YYYY-MM-DD"
+                value={draft.toStr}
                 onChange={(e) => handleManualDate("to", e.target.value)}
                 className="h-7 flex-1 text-xs"
               />
+            </div>
+            <div className="flex items-center justify-end gap-2 px-2 pb-2">
+              <Button
+                type="button"
+                size="xs"
+                variant="ghost"
+                onClick={handleClear}
+              >
+                Clear
+              </Button>
+              <Button
+                type="button"
+                size="xs"
+                variant="default"
+                onClick={handleApply}
+              >
+                Apply
+              </Button>
             </div>
           </div>
         </div>

--- a/app/lib/queries/date-range.ts
+++ b/app/lib/queries/date-range.ts
@@ -1,0 +1,45 @@
+type SearchParams = Record<string, string | string[] | undefined>;
+
+interface Options {
+  applyDefault?: boolean;
+  defaultDays?: number;
+}
+
+function coerce(value: string | string[] | undefined): string | undefined {
+  const v = Array.isArray(value) ? value[0] : value;
+  return v || undefined;
+}
+
+function todayMinusDays(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function getDateRangeFromParams(
+  params: SearchParams,
+  opts: { applyDefault: false; defaultDays?: number }
+): { dateFrom: string | undefined; dateTo: string | undefined };
+export function getDateRangeFromParams(
+  params: SearchParams,
+  opts?: { applyDefault?: true; defaultDays?: number }
+): { dateFrom: string; dateTo: string | undefined };
+export function getDateRangeFromParams(
+  params: SearchParams,
+  opts: Options = {}
+): { dateFrom: string | undefined; dateTo: string | undefined } {
+  const { applyDefault = true, defaultDays = 30 } = opts;
+
+  let dateFrom = coerce(params.dateFrom);
+  let dateTo = coerce(params.dateTo);
+
+  if (dateFrom && dateTo && dateFrom > dateTo) {
+    [dateFrom, dateTo] = [dateTo, dateFrom];
+  }
+
+  if (applyDefault && !dateFrom) {
+    dateFrom = todayMinusDays(defaultDays);
+  }
+
+  return { dateFrom, dateTo };
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-stack",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-stack",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@tanstack/react-table": "^8.21.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-stack",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3001",


### PR DESCRIPTION
Rewrites the date range picker around a draft-and-commit pattern: calendar clicks and typed input update local draft state, and the URL is only updated on explicit Apply / Clear (or Quick Select). Manual date fields are now plain text inputs (YYYY-MM-DD) — no native browser calendar overlay, no dropped keystrokes when typing. Click tracking uses triggerDate directly so clicking inside a complete range starts a fresh selection from that date instead of collapsing to the closer endpoint. Extracts the duplicated 30-day default into a shared `getDateRangeFromParams` helper used by all 8 consumers.