### PR TITLE
Issue #107 - Transactions table polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,17 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
 
+### 2026-05-13 — v0.1.3 (in progress)
+
+**Sortable columns: single source of truth (Issue #107)**
+- Made `SORTABLE_COLUMNS` in `lib/queries/transactions.ts` the single source of truth for the sortable-column whitelist. Added a derived `SORTABLE_COLUMN_KEYS = Object.keys(SORTABLE_COLUMNS) as SortableColumn[]` export and removed the duplicated `VALID_SORT_COLUMNS` array from `dashboard/transactions/page.tsx`.
+- Eliminates the silent-bug class where adding a column to `SORTABLE_COLUMNS` but forgetting to update the page's whitelist caused the `?sortBy=` URL param to be dropped on the server with no error — the bug originally hit when adding the Related Account column in #105. Adding a new entry to `SORTABLE_COLUMNS` now makes that column sortable end-to-end with no other file changes; the `SortableColumn` union keeps the runtime whitelist in lockstep automatically.
+
+**Transactions table: stable column widths across sorts**
+- Sorting a column previously shifted every column's width because the default `table-layout: auto` re-derives widths from cell content. After a sort the longest visible value in each column changed, so the sort button you'd just clicked physically moved — requiring a mouse reposition to click again for the reverse sort.
+- Switched the Transactions table to `table-fixed` and assigned explicit Tailwind width tokens per column (`w-28` for date/type, `w-32` for amount, `w-40` for category, `w-44` for account/related account, `w-80` for description). Added `truncate` on text cells so long values get an ellipsis instead of expanding the column.
+- Sort button positions now stay put across sorts and other data changes (pagination, filtering).
+
 ### 2026-05-10 — v0.1.3 (in progress)
 
 **Date Range filter UX fixes (related to Issue #61)**

--- a/app/app/(app)/dashboard/transactions/page.tsx
+++ b/app/app/(app)/dashboard/transactions/page.tsx
@@ -3,6 +3,7 @@ import {
   getFilteredTransactions,
   getFilteredTransactionsCount,
   getUniqueDescriptions,
+  SORTABLE_COLUMN_KEYS,
   type TransactionFilters,
   type SortableColumn,
   type SortDirection,
@@ -43,10 +44,6 @@ function parseSearchParams(
     return items.length > 0 ? items : undefined;
   };
 
-  const VALID_SORT_COLUMNS: SortableColumn[] = [
-    "transactionDate", "transactionDescription", "amount",
-    "accountName", "relatedAccountName", "transactionType", "transactionCategory",
-  ];
   const VALID_SORT_DIRS: SortDirection[] = ["asc", "desc"];
 
   const rawSortBy = get("sortBy");
@@ -67,7 +64,7 @@ function parseSearchParams(
     accountIds: getNumberArray("accountIds"),
     typeIds: getNumberArray("typeIds"),
     categoryIds: getNumberArray("categoryIds"),
-    sortBy: VALID_SORT_COLUMNS.includes(rawSortBy as SortableColumn)
+    sortBy: SORTABLE_COLUMN_KEYS.includes(rawSortBy as SortableColumn)
       ? (rawSortBy as SortableColumn)
       : undefined,
     sortDir: VALID_SORT_DIRS.includes(rawSortDir as SortDirection)

--- a/app/components/transactions/transaction-list.tsx
+++ b/app/components/transactions/transaction-list.tsx
@@ -91,19 +91,22 @@ const COLUMNS: ColumnDef[] = [
     key: "date",
     label: "Date",
     sortColumn: "transactionDate",
+    headClassName: "w-28",
     render: (txn) => formatDate(txn.transactionDate),
   },
   {
     key: "description",
     label: "Description",
     sortColumn: "transactionDescription",
+    headClassName: "w-80",
+    cellClassName: "truncate",
     render: (txn) => txn.transactionDescription,
   },
   {
     key: "amount",
     label: "Amount",
     sortColumn: "amount",
-    headClassName: "text-right",
+    headClassName: "w-32 text-right",
     cellClassName: "text-right",
     render: (txn) => {
       const amount = Number(txn.amount ?? 0);
@@ -118,24 +121,32 @@ const COLUMNS: ColumnDef[] = [
     key: "account",
     label: "Account",
     sortColumn: "accountName",
+    headClassName: "w-44",
+    cellClassName: "truncate",
     render: (txn) => txn.accountName,
   },
   {
     key: "relatedAccount",
     label: "Related Account",
     sortColumn: "relatedAccountName",
+    headClassName: "w-44",
+    cellClassName: "truncate",
     render: (txn) => txn.relatedAccountName,
   },
   {
     key: "type",
     label: "Type",
     sortColumn: "transactionType",
+    headClassName: "w-28",
+    cellClassName: "truncate",
     render: (txn) => txn.transactionType,
   },
   {
     key: "category",
     label: "Category",
     sortColumn: "transactionCategory",
+    headClassName: "w-40",
+    cellClassName: "truncate",
     render: (txn) => txn.transactionCategory,
   },
 ];
@@ -351,7 +362,7 @@ export function TransactionList({
             : "No transactions yet."}
         </p>
       ) : (
-        <Table>
+        <Table className="table-fixed">
           <TableHeader>
             <TableRow>
               {filteredColumns.map((col) => (

--- a/app/lib/queries/transactions.ts
+++ b/app/lib/queries/transactions.ts
@@ -23,6 +23,8 @@ const SORTABLE_COLUMNS: Record<SortableColumn, Column> = {
   transactionCategory: vTransactionsFull.transactionCategory,
 };
 
+export const SORTABLE_COLUMN_KEYS = Object.keys(SORTABLE_COLUMNS) as SortableColumn[];
+
 export interface TransactionFilters {
   dateFrom?: string;
   dateTo?: string;


### PR DESCRIPTION
DRY sort whitelist + stable column widths

Derives the sortBy URL-param whitelist from SORTABLE_COLUMNS so adding a sortable column no longer requires editing two files (fixes the silent-drop class of bug hit when adding Related Account in #105). Switches to table-fixed with explicit column widths so the sort button stays at the same pixel position across clicks.