### PR TITLE
Issue #106 - Persist Transactions column visibility in a cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ finance-stack/
 │   │       ├── transaction-list.tsx      # Sortable transaction table with inline edit + delete (client component)
 │   │       ├── transaction-edit-row.tsx  # Inline row-edit form (client component, uses updateTransaction action)
 │   │       ├── transaction-delete-dialog.tsx # Delete confirmation modal (uses deleteTransaction action)
-│   │       └── transaction-filters.tsx   # Filter bar with date range, multi-select, amount
+│   │       ├── transaction-filters.tsx   # Filter bar with date range, multi-select, amount
+│   │       └── transaction-columns.ts    # Shared ColumnKey type + visible-columns cookie helpers (server- and client-safe)
 │   ├── lib/                              # Shared libraries
 │   │   ├── db/index.ts                   # Drizzle ORM client (PostgreSQL connection)
 │   │   ├── actions/utils.ts              # Shared ActionState type and buildFieldErrors() helper
@@ -377,6 +378,11 @@ Data is persisted in Docker volumes and will be available on next startup.
 ## Updates
 
 ### 2026-05-13 — v0.1.3 (in progress)
+
+**Transactions column visibility: cookie-backed persistence (Issue #106)**
+- Moved Transactions table column-visibility persistence from `localStorage` to a `txn-visible-columns` cookie (`Path=/; SameSite=Lax; Max-Age=1 year`, URL-encoded JSON array of column keys). The dashboard page now reads the cookie server-side via `next/headers` `cookies()` and passes the validated list as a prop, so SSR and the initial client render emit the user's preferred columns directly. Eliminates the visible flash on every reload where hidden columns briefly appeared before disappearing.
+- Hard cutover: existing users' `localStorage` preference is ignored. Anyone who had previously hidden columns will see all columns once on first load, then re-hide via the Columns popover (which now writes the cookie).
+- Sidebar `defaultOpen` has the same SSR-read gap and is intentionally deferred to a follow-up — this change is scoped to the Transactions table.
 
 **Sortable columns: single source of truth (Issue #107)**
 - Made `SORTABLE_COLUMNS` in `lib/queries/transactions.ts` the single source of truth for the sortable-column whitelist. Added a derived `SORTABLE_COLUMN_KEYS = Object.keys(SORTABLE_COLUMNS) as SortableColumn[]` export and removed the duplicated `VALID_SORT_COLUMNS` array from `dashboard/transactions/page.tsx`.

--- a/app/app/(app)/dashboard/transactions/page.tsx
+++ b/app/app/(app)/dashboard/transactions/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from "next/headers";
 import {
   getTransactionFormOptions,
   getFilteredTransactions,
@@ -12,6 +13,10 @@ import { getDateRangeFromParams } from "@/lib/queries/date-range";
 import { TransactionForm } from "@/components/transactions/transaction-form";
 import { TransactionFilters as TransactionFiltersUI } from "@/components/transactions/transaction-filters";
 import { TransactionList } from "@/components/transactions/transaction-list";
+import {
+  VISIBLE_COLUMNS_COOKIE,
+  parseVisibleColumnsCookie,
+} from "@/components/transactions/transaction-columns";
 import {
   Card,
   CardContent,
@@ -83,6 +88,11 @@ export default async function DashboardTransactionsPage({
   const resolvedParams = await searchParams;
   const filters = parseSearchParams(resolvedParams);
 
+  const cookieStore = await cookies();
+  const visibleColumns = parseVisibleColumnsCookie(
+    cookieStore.get(VISIBLE_COLUMNS_COOKIE)?.value
+  );
+
   const [{ accounts, types, categories }, transactions, descriptions, totalCount] =
     await Promise.all([
       getTransactionFormOptions(),
@@ -122,6 +132,7 @@ export default async function DashboardTransactionsPage({
             accounts={accounts}
             types={types}
             categories={categories}
+            visibleColumns={visibleColumns}
           />
         </CardContent>
       </Card>

--- a/app/components/transactions/transaction-columns.ts
+++ b/app/components/transactions/transaction-columns.ts
@@ -1,0 +1,37 @@
+export type ColumnKey =
+  | "date"
+  | "description"
+  | "amount"
+  | "account"
+  | "relatedAccount"
+  | "type"
+  | "category";
+
+export const ALL_COLUMN_KEYS: ColumnKey[] = [
+  "date",
+  "description",
+  "amount",
+  "account",
+  "relatedAccount",
+  "type",
+  "category",
+];
+
+export const VISIBLE_COLUMNS_COOKIE = "txn-visible-columns";
+export const VISIBLE_COLUMNS_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+export function parseVisibleColumnsCookie(
+  value: string | undefined
+): ColumnKey[] {
+  if (!value) return [...ALL_COLUMN_KEYS];
+  try {
+    const parsed = JSON.parse(decodeURIComponent(value)) as unknown;
+    if (!Array.isArray(parsed)) return [...ALL_COLUMN_KEYS];
+    const valid = parsed.filter((k): k is ColumnKey =>
+      ALL_COLUMN_KEYS.includes(k as ColumnKey)
+    );
+    return valid.length > 0 ? valid : [...ALL_COLUMN_KEYS];
+  } catch {
+    return [...ALL_COLUMN_KEYS];
+  }
+}

--- a/app/components/transactions/transaction-list.tsx
+++ b/app/components/transactions/transaction-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   ArrowUpIcon,
   ArrowDownIcon,
@@ -29,6 +29,11 @@ import { amountColorClass } from "@/components/accounts/accounts-table";
 import type { SortableColumn, SortDirection } from "@/lib/queries/transactions";
 import { TransactionEditRow } from "@/components/transactions/transaction-edit-row";
 import { TransactionDeleteDialog } from "@/components/transactions/transaction-delete-dialog";
+import {
+  VISIBLE_COLUMNS_COOKIE,
+  VISIBLE_COLUMNS_COOKIE_MAX_AGE,
+  type ColumnKey,
+} from "@/components/transactions/transaction-columns";
 
 // ── Types ──
 
@@ -52,15 +57,6 @@ interface LookupOption {
   id: number;
   name: string;
 }
-
-export type ColumnKey =
-  | "date"
-  | "description"
-  | "amount"
-  | "account"
-  | "relatedAccount"
-  | "type"
-  | "category";
 
 interface ColumnDef {
   key: ColumnKey;
@@ -151,29 +147,6 @@ const COLUMNS: ColumnDef[] = [
   },
 ];
 
-const ALL_COLUMN_KEYS: ColumnKey[] = COLUMNS.map((c) => c.key);
-
-// ── Column visibility (localStorage) ──
-
-const STORAGE_KEY = "txn-visible-columns";
-
-function loadVisibleColumns(): Set<ColumnKey> {
-  if (typeof window === "undefined") return new Set(ALL_COLUMN_KEYS);
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const parsed = JSON.parse(stored) as string[];
-      const valid = parsed.filter((k): k is ColumnKey =>
-        ALL_COLUMN_KEYS.includes(k as ColumnKey)
-      );
-      if (valid.length > 0) return new Set(valid);
-    }
-  } catch {
-    // ignore
-  }
-  return new Set(ALL_COLUMN_KEYS);
-}
-
 // ── Sub-components ──
 
 function SortableHead({
@@ -228,6 +201,7 @@ export function TransactionList({
   accounts,
   types,
   categories,
+  visibleColumns: initialVisibleColumns,
 }: {
   transactions: TransactionRow[];
   hasFilters?: boolean;
@@ -239,6 +213,7 @@ export function TransactionList({
   accounts: LookupOption[];
   types: LookupOption[];
   categories: LookupOption[];
+  visibleColumns: ColumnKey[];
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -261,17 +236,9 @@ export function TransactionList({
     [editingId]
   );
 
-  // Column visibility — initialize with all, then load from localStorage on mount.
-  // Two-step init avoids hydration mismatch: SSR and initial client render both
-  // use ALL_COLUMN_KEYS; localStorage preference is applied after mount.
   const [visibleColumns, setVisibleColumns] = useState<Set<ColumnKey>>(
-    () => new Set(ALL_COLUMN_KEYS)
+    () => new Set(initialVisibleColumns)
   );
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: post-mount hydration step to load persisted column preference from localStorage
-    setVisibleColumns(loadVisibleColumns());
-  }, []);
 
   const toggleColumn = useCallback((key: ColumnKey) => {
     setVisibleColumns((prev) => {
@@ -281,7 +248,8 @@ export function TransactionList({
       } else {
         next.add(key);
       }
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
+      const encoded = encodeURIComponent(JSON.stringify([...next]));
+      document.cookie = `${VISIBLE_COLUMNS_COOKIE}=${encoded}; path=/; max-age=${VISIBLE_COLUMNS_COOKIE_MAX_AGE}; samesite=lax`;
       return next;
     });
   }, []);


### PR DESCRIPTION
## Summary
- Moves Transactions table column-visibility persistence from `localStorage` to a `txn-visible-columns` cookie (URL-encoded JSON array of `ColumnKey`s; `Path=/; SameSite=Lax; Max-Age=1 year`). The dashboard page now reads the cookie server-side via `next/headers` `cookies()` and passes the validated list as a prop, so SSR and the initial client render emit the user's preferred columns directly. Eliminates the visible flash on every reload where hidden columns briefly appeared before disappearing.
- Extracted the cookie contract (`ColumnKey`, `ALL_COLUMN_KEYS`, `VISIBLE_COLUMNS_COOKIE`, `VISIBLE_COLUMNS_COOKIE_MAX_AGE`, `parseVisibleColumnsCookie`) into a new server- and client-safe module `app/components/transactions/transaction-columns.ts` so the server component and the `TransactionList` client component share one source of truth.
- **Hard cutover**: existing users' `localStorage` value is ignored — anyone with previously hidden columns will see all columns once on first reload after this lands, then re-hide via the Columns popover (which now writes the cookie).
- Sidebar `defaultOpen` has the same SSR-read gap; intentionally deferred to a follow-up to keep this PR scoped to the Transactions table.

## Test plan
- [x] Toggle a column off via the Columns popover, hard-reload `/dashboard/transactions` — the column does NOT flash before disappearing.
- [x] `curl -s -H 'Cookie: txn-visible-columns=%5B%22date%22%2C%22description%22%2C%22amount%22%5D' http://localhost:3001/dashboard/transactions | grep -E '<th|Date|Account|Category'` — only the three requested column headers appear in the SSR HTML.
- [x] DevTools → Application → Cookies — `txn-visible-columns` has `Path=/`, `SameSite=Lax`, ~1-year expiry after a toggle.
- [x] Try to uncheck the last visible column — guard holds, it stays checked.
- [x] Set `Cookie: txn-visible-columns=not-json` (and a JSON array of unknown keys like `["bogus"]`) — page renders with all columns in both cases; toggling works normally.
- [x] `npm run lint` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)