### PR TITLE
Issue #61 - Quick Select macros for Date Range Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ finance-stack/
 │   │   │   ├── currency-input.tsx        # Numeric currency entry with symbol prefix (custom)
 │   │   │   ├── date-picker.tsx           # Single-date calendar popover (custom)
 │   │   │   ├── date-range-picker.tsx     # Date range with quick-select presets + manual input (custom)
+│   │   │   ├── date-range-macros.ts      # Saved Quick Select macros: types, built-in defaults, localStorage helpers
 │   │   │   └── input-group.tsx           # Input with inline prefix/suffix slot (custom)
 │   │   ├── charts/                       # Chart components (client components)
 │   │   │   ├── accounting-chart.tsx      # Time-series area chart for income/expenses/investments (Chart.js)
@@ -307,7 +308,7 @@ finance-stack/
 │   │   ├── unit/                         # Unit tests (no DB required)
 │   │   │   ├── validations/              #   Zod schema tests (account, transaction, categories)
 │   │   │   ├── actions/                  #   Action utility tests (buildFieldErrors)
-│   │   │   ├── components/               #   Component function tests (waterfall transform, liquidity, asset perf, debt-mix, debt-waterfall, liability perf)
+│   │   │   ├── components/               #   Component function tests (waterfall transform, liquidity, asset perf, debt-mix, debt-waterfall, liability perf, date-range macros)
 │   │   │   └── lib/                      #   Library utility tests
 │   │   │       ├── utils.test.ts         #     cn() class-merge helper
 │   │   │       ├── forms/                #     Form helpers (transaction post-submit state)
@@ -376,6 +377,16 @@ docker compose down
 Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
+
+### 2026-05-14 — v0.1.3 (in progress)
+
+**Quick Select macros for the Date Range Picker ([Issue #61](https://github.com/aellington89/finance-stack/issues/61))**
+- The Date Range Picker's Quick Select panel now lists four built-in one-click presets (Last 7 days, Last 30 days, This month, This year) above the existing `Last/This + count + Days/Weeks/Months/Years` builder. Built-ins are non-deletable and never stored — they always reflect today's date, so "Last 30 days" stays a rolling window.
+- Users can save the current builder configuration as a named macro via a new **Save as…** button next to Apply. Saved macros appear under a "Saved" header between the built-ins and the builder. Hover a saved macro to reveal a delete affordance. Clicking any macro (built-in or saved) applies the range and closes the popover — same path as Apply.
+- Macros are persisted in `localStorage` under the key `dateRangeMacros` as `{ version: 1, macros: [...] }`. This diverges from the cookie-based persistence used elsewhere in the repo (`txn-visible-columns`, `sidebar_state`) because macros are pure client-side UI state — never read server-side, never affect initial HTML, never participate in auth — which is the standard industry choice for this class of preference (see [Issue #118](https://github.com/aellington89/finance-stack/issues/118) for evaluating whether the existing cookie usages should also move). All localStorage access is wrapped so private-mode browsers degrade gracefully: built-ins still work, saves no-op silently.
+- Names are trimmed, capped at 50 characters, deduplicated case-insensitively (including against built-in names), and limited to a hard cap of **10 user macros**. The Save as… button is disabled at the cap; the in-input save attempt surfaces a `"Macro limit reached — delete one to add another"` error inline.
+- Both consumers — the Transactions filter ([transaction-filters.tsx](app/components/transactions/transaction-filters.tsx)) and the Dashboard date filter ([date-range-filter.tsx](app/components/dashboard/date-range-filter.tsx)) — pick up macros automatically with no code changes; the picker's `onChange(from, to)` contract is unchanged.
+- New module `app/components/ui/date-range-macros.ts` is the schema source of truth for the `Scope` and `Unit` types (previously inlined in `date-range-picker.tsx`) and exports defensive `parseStoredMacros`, `loadMacros`, `saveMacros`, `addMacro`, and `deleteMacro` helpers. Unit tests in `tests/unit/components/date-range-macros.test.ts` cover parse defensiveness (malformed JSON, invalid scope/unit, name length, missing fields), dedupe rules, the cap, delete semantics, and the localStorage-unavailable path via stubbed globals.
 
 ### 2026-05-13 — v0.1.3 (in progress)
 

--- a/app/components/ui/date-range-macros.ts
+++ b/app/components/ui/date-range-macros.ts
@@ -1,0 +1,142 @@
+export type Scope = "last" | "this";
+export type Unit = "days" | "weeks" | "months" | "years";
+
+export type MacroInput = {
+  name: string;
+  scope: Scope;
+  count: number;
+  unit: Unit;
+};
+
+export type Macro = MacroInput & {
+  id: string;
+};
+
+export type BuiltInMacro = {
+  id: string;
+  name: string;
+  scope: Scope;
+  count: number;
+  unit: Unit;
+};
+
+export const MACRO_STORAGE_KEY = "dateRangeMacros";
+export const MACRO_LIMIT = 10;
+export const MACRO_NAME_MAX_LENGTH = 50;
+const STORAGE_VERSION = 1;
+
+export const BUILT_IN_MACROS: ReadonlyArray<BuiltInMacro> = [
+  { id: "builtin:last-7-days", name: "Last 7 days", scope: "last", count: 7, unit: "days" },
+  { id: "builtin:last-30-days", name: "Last 30 days", scope: "last", count: 30, unit: "days" },
+  { id: "builtin:this-month", name: "This month", scope: "this", count: 1, unit: "months" },
+  { id: "builtin:this-year", name: "This year", scope: "this", count: 1, unit: "years" },
+];
+
+const VALID_SCOPES: ReadonlySet<Scope> = new Set<Scope>(["last", "this"]);
+const VALID_UNITS: ReadonlySet<Unit> = new Set<Unit>(["days", "weeks", "months", "years"]);
+
+function isValidMacro(value: unknown): value is Macro {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "string" &&
+    v.id.length > 0 &&
+    typeof v.name === "string" &&
+    v.name.length > 0 &&
+    v.name.length <= MACRO_NAME_MAX_LENGTH &&
+    typeof v.scope === "string" &&
+    VALID_SCOPES.has(v.scope as Scope) &&
+    typeof v.count === "number" &&
+    Number.isFinite(v.count) &&
+    v.count >= 1 &&
+    typeof v.unit === "string" &&
+    VALID_UNITS.has(v.unit as Unit)
+  );
+}
+
+export function parseStoredMacros(value: string | null | undefined): Macro[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+    const macros = (parsed as { macros?: unknown }).macros;
+    if (!Array.isArray(macros)) return [];
+    return macros.filter(isValidMacro).slice(0, MACRO_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+function serializeMacros(macros: Macro[]): string {
+  return JSON.stringify({ version: STORAGE_VERSION, macros });
+}
+
+export function loadMacros(): Macro[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return parseStoredMacros(window.localStorage.getItem(MACRO_STORAGE_KEY));
+  } catch {
+    return [];
+  }
+}
+
+export function saveMacros(macros: Macro[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MACRO_STORAGE_KEY, serializeMacros(macros));
+  } catch {
+    // localStorage unavailable (private mode, quota exceeded, blocked) —
+    // the in-memory list still works for this session.
+  }
+}
+
+export type AddMacroResult =
+  | { ok: true; macros: Macro[]; added: Macro }
+  | { ok: false; error: string };
+
+export function addMacro(existing: Macro[], input: MacroInput): AddMacroResult {
+  const name = input.name.trim();
+  if (!name) {
+    return { ok: false, error: "Name is required" };
+  }
+  if (name.length > MACRO_NAME_MAX_LENGTH) {
+    return { ok: false, error: `Name must be at most ${MACRO_NAME_MAX_LENGTH} characters` };
+  }
+  const lower = name.toLowerCase();
+  const builtInClash = BUILT_IN_MACROS.some((m) => m.name.toLowerCase() === lower);
+  const userClash = existing.some((m) => m.name.toLowerCase() === lower);
+  if (builtInClash || userClash) {
+    return { ok: false, error: "A macro with that name already exists" };
+  }
+  if (existing.length >= MACRO_LIMIT) {
+    return { ok: false, error: "Macro limit reached — delete one to add another" };
+  }
+  if (!VALID_SCOPES.has(input.scope)) {
+    return { ok: false, error: "Invalid scope" };
+  }
+  if (!VALID_UNITS.has(input.unit)) {
+    return { ok: false, error: "Invalid unit" };
+  }
+  if (!Number.isFinite(input.count) || input.count < 1) {
+    return { ok: false, error: "Count must be a positive number" };
+  }
+  const added: Macro = {
+    id: createMacroId(),
+    name,
+    scope: input.scope,
+    count: input.count,
+    unit: input.unit,
+  };
+  return { ok: true, macros: [...existing, added], added };
+}
+
+export function deleteMacro(existing: Macro[], id: string): Macro[] {
+  return existing.filter((m) => m.id !== id);
+}
+
+function createMacroId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `m_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/app/components/ui/date-range-picker.tsx
+++ b/app/components/ui/date-range-picker.tsx
@@ -14,7 +14,7 @@ import {
   endOfYear,
   format,
 } from "date-fns"
-import { CalendarIcon, ArrowRightIcon } from "lucide-react"
+import { CalendarIcon, ArrowRightIcon, XIcon } from "lucide-react"
 import type { DateRange } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
@@ -26,6 +26,18 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import {
+  BUILT_IN_MACROS,
+  MACRO_LIMIT,
+  MACRO_NAME_MAX_LENGTH,
+  addMacro,
+  deleteMacro,
+  loadMacros,
+  saveMacros,
+  type Macro,
+  type Scope,
+  type Unit,
+} from "@/components/ui/date-range-macros"
 
 interface DateRangePickerProps {
   dateFrom?: string
@@ -34,9 +46,6 @@ interface DateRangePickerProps {
   className?: string
   placeholder?: string
 }
-
-type Scope = "last" | "this"
-type Unit = "days" | "weeks" | "months" | "years"
 
 function computeQuickRange(
   scope: Scope,
@@ -116,61 +125,226 @@ function QuickSelect({
   const [count, setCount] = React.useState(30)
   const [unit, setUnit] = React.useState<Unit>("days")
 
-  const handleApply = () => {
-    const range = computeQuickRange(scope, count, unit)
+  const [userMacros, setUserMacros] = React.useState<Macro[]>([])
+  const [hydrated, setHydrated] = React.useState(false)
+  const [isSaving, setIsSaving] = React.useState(false)
+  const [saveName, setSaveName] = React.useState("")
+  const [saveError, setSaveError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    setUserMacros(loadMacros())
+    setHydrated(true)
+  }, [])
+
+  const applyConfig = (config: { scope: Scope; count: number; unit: Unit }) => {
+    const range = computeQuickRange(config.scope, config.count, config.unit)
     onApply(range.from, range.to)
   }
 
+  const handleApply = () => {
+    applyConfig({ scope, count, unit })
+  }
+
+  const handleStartSave = () => {
+    setIsSaving(true)
+    setSaveName("")
+    setSaveError(null)
+  }
+
+  const handleCancelSave = () => {
+    setIsSaving(false)
+    setSaveName("")
+    setSaveError(null)
+  }
+
+  const handleConfirmSave = () => {
+    const result = addMacro(userMacros, { name: saveName, scope, count, unit })
+    if (!result.ok) {
+      setSaveError(result.error)
+      return
+    }
+    setUserMacros(result.macros)
+    saveMacros(result.macros)
+    setIsSaving(false)
+    setSaveName("")
+    setSaveError(null)
+  }
+
+  const handleDeleteMacro = (id: string) => {
+    const next = deleteMacro(userMacros, id)
+    setUserMacros(next)
+    saveMacros(next)
+  }
+
+  const atLimit = userMacros.length >= MACRO_LIMIT
+
   return (
-    <div className="space-y-2 p-2">
+    <div className="w-52 space-y-2 p-2">
       <p className="px-1 text-xs font-medium text-muted-foreground">
         Quick select
       </p>
-      <div className="flex items-center gap-1.5">
-        <select
-          value={scope}
-          onChange={(e) => setScope(e.target.value as Scope)}
-          className="h-7 rounded-md border border-input bg-popover text-popover-foreground px-1.5 text-xs outline-none focus:border-ring focus:ring-1 focus:ring-ring/50"
-        >
-          {SCOPES.map((s) => (
-            <option key={s.value} value={s.value}>
-              {s.label}
-            </option>
-          ))}
-        </select>
-        {scope === "last" && (
-          <Input
-            type="number"
-            min={1}
-            max={999}
-            value={count}
-            onChange={(e) => setCount(Math.max(1, Number(e.target.value) || 1))}
-            className="h-7 w-14 px-1.5 text-xs"
-          />
-        )}
-        <select
-          value={unit}
-          onChange={(e) => setUnit(e.target.value as Unit)}
-          className="h-7 rounded-md border border-input bg-popover text-popover-foreground px-1.5 text-xs outline-none focus:border-ring focus:ring-1 focus:ring-ring/50"
-        >
-          {UNITS.map((u) => (
-            <option key={u.value} value={u.value}>
-              {scope === "this" && u.value !== "days"
-                ? u.label.replace(/s$/, "")
-                : u.label}
-            </option>
-          ))}
-        </select>
+
+      <div className="space-y-0.5">
+        {BUILT_IN_MACROS.map((m) => (
+          <Button
+            key={m.id}
+            type="button"
+            size="xs"
+            variant="ghost"
+            className="w-full justify-start px-2 text-xs font-normal"
+            onClick={() => applyConfig(m)}
+          >
+            {m.name}
+          </Button>
+        ))}
       </div>
-      <Button
-        type="button"
-        size="xs"
-        variant="secondary"
-        onClick={handleApply}
-        className="w-full"
-      >
-        Apply
-      </Button>
+
+      {hydrated && userMacros.length > 0 && (
+        <div className="space-y-0.5">
+          <p className="px-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Saved
+          </p>
+          {userMacros.map((m) => (
+            <div key={m.id} className="group flex items-center gap-0.5">
+              <Button
+                type="button"
+                size="xs"
+                variant="ghost"
+                className="flex-1 justify-start px-2 text-xs font-normal"
+                onClick={() => applyConfig(m)}
+              >
+                <span className="truncate">{m.name}</span>
+              </Button>
+              <Button
+                type="button"
+                size="xs"
+                variant="ghost"
+                aria-label={`Delete ${m.name}`}
+                className="size-6 shrink-0 px-0 text-muted-foreground opacity-0 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+                onClick={() => handleDeleteMacro(m.id)}
+              >
+                <XIcon className="size-3" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="space-y-2 border-t pt-2">
+        <div className="flex items-center gap-1.5">
+          <select
+            value={scope}
+            onChange={(e) => setScope(e.target.value as Scope)}
+            className="h-7 rounded-md border border-input bg-popover text-popover-foreground px-1.5 text-xs outline-none focus:border-ring focus:ring-1 focus:ring-ring/50"
+          >
+            {SCOPES.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+          {scope === "last" && (
+            <Input
+              type="number"
+              min={1}
+              max={999}
+              value={count}
+              onChange={(e) => setCount(Math.max(1, Number(e.target.value) || 1))}
+              className="h-7 w-14 px-1.5 text-xs"
+            />
+          )}
+          <select
+            value={unit}
+            onChange={(e) => setUnit(e.target.value as Unit)}
+            className="h-7 rounded-md border border-input bg-popover text-popover-foreground px-1.5 text-xs outline-none focus:border-ring focus:ring-1 focus:ring-ring/50"
+          >
+            {UNITS.map((u) => (
+              <option key={u.value} value={u.value}>
+                {scope === "this" && u.value !== "days"
+                  ? u.label.replace(/s$/, "")
+                  : u.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {!isSaving ? (
+          <div className="flex gap-1">
+            <Button
+              type="button"
+              size="xs"
+              variant="secondary"
+              onClick={handleApply}
+              className="flex-1"
+            >
+              Apply
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              onClick={handleStartSave}
+              disabled={atLimit}
+              title={
+                atLimit
+                  ? "Macro limit reached — delete one to add another"
+                  : undefined
+              }
+              className="flex-1"
+            >
+              Save as…
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            <Input
+              type="text"
+              autoFocus
+              maxLength={MACRO_NAME_MAX_LENGTH}
+              value={saveName}
+              onChange={(e) => {
+                setSaveName(e.target.value)
+                setSaveError(null)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault()
+                  handleConfirmSave()
+                } else if (e.key === "Escape") {
+                  e.preventDefault()
+                  handleCancelSave()
+                }
+              }}
+              placeholder="Macro name"
+              className="h-7 text-xs"
+            />
+            <div className="flex gap-1">
+              <Button
+                type="button"
+                size="xs"
+                variant="default"
+                onClick={handleConfirmSave}
+                disabled={!saveName.trim()}
+                className="flex-1"
+              >
+                Save
+              </Button>
+              <Button
+                type="button"
+                size="xs"
+                variant="ghost"
+                onClick={handleCancelSave}
+                className="flex-1"
+              >
+                Cancel
+              </Button>
+            </div>
+            {saveError && (
+              <p className="text-[10px] text-destructive">{saveError}</p>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/app/tests/unit/components/date-range-macros.test.ts
+++ b/app/tests/unit/components/date-range-macros.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  parseStoredMacros,
+  addMacro,
+  deleteMacro,
+  loadMacros,
+  saveMacros,
+  MACRO_LIMIT,
+  MACRO_NAME_MAX_LENGTH,
+  type Macro,
+} from "@/components/ui/date-range-macros";
+
+const validMacro = (overrides: Partial<Macro> = {}): Macro => ({
+  id: "id-1",
+  name: "Valid",
+  scope: "last",
+  count: 30,
+  unit: "days",
+  ...overrides,
+});
+
+describe("parseStoredMacros", () => {
+  it("returns [] for null / undefined / empty string", () => {
+    expect(parseStoredMacros(null)).toEqual([]);
+    expect(parseStoredMacros(undefined)).toEqual([]);
+    expect(parseStoredMacros("")).toEqual([]);
+  });
+
+  it("returns [] for malformed JSON", () => {
+    expect(parseStoredMacros("{not json")).toEqual([]);
+  });
+
+  it("returns [] when the top-level value is not an object", () => {
+    expect(parseStoredMacros("[]")).toEqual([]);
+    expect(parseStoredMacros("42")).toEqual([]);
+    expect(parseStoredMacros("null")).toEqual([]);
+    expect(parseStoredMacros('"string"')).toEqual([]);
+  });
+
+  it("returns [] when macros is missing or not an array", () => {
+    expect(parseStoredMacros(JSON.stringify({ version: 1 }))).toEqual([]);
+    expect(parseStoredMacros(JSON.stringify({ version: 1, macros: "nope" }))).toEqual([]);
+  });
+
+  it("filters out structurally invalid macro entries", () => {
+    const stored = JSON.stringify({
+      version: 1,
+      macros: [
+        validMacro({ id: "ok", name: "OK" }),
+        { ...validMacro(), scope: "next" },
+        { ...validMacro(), unit: "decades" },
+        { ...validMacro(), name: "" },
+        { ...validMacro(), count: -5 },
+        { ...validMacro(), count: 0 },
+        { ...validMacro(), count: "30" },
+        { id: "", name: "Empty id", scope: "last", count: 7, unit: "days" },
+        "not an object",
+        null,
+        { name: "Missing id", scope: "last", count: 7, unit: "days" },
+      ],
+    });
+    const result = parseStoredMacros(stored);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("OK");
+  });
+
+  it("rejects names longer than the max length", () => {
+    const stored = JSON.stringify({
+      version: 1,
+      macros: [validMacro({ name: "x".repeat(MACRO_NAME_MAX_LENGTH + 1) })],
+    });
+    expect(parseStoredMacros(stored)).toEqual([]);
+  });
+
+  it("caps the returned list at MACRO_LIMIT", () => {
+    const macros = Array.from({ length: MACRO_LIMIT + 5 }, (_, i) =>
+      validMacro({ id: `m${i}`, name: `Macro ${i}` })
+    );
+    const result = parseStoredMacros(JSON.stringify({ version: 1, macros }));
+    expect(result).toHaveLength(MACRO_LIMIT);
+  });
+});
+
+describe("addMacro", () => {
+  const input = { name: "Test", scope: "last", count: 14, unit: "days" } as const;
+
+  it("adds a valid macro and assigns a non-empty id", () => {
+    const result = addMacro([], input);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.macros).toHaveLength(1);
+    expect(result.macros[0].id).toBeTruthy();
+    expect(result.macros[0].name).toBe("Test");
+    expect(result.added).toEqual(result.macros[0]);
+  });
+
+  it("trims whitespace from the name", () => {
+    const result = addMacro([], { ...input, name: "  Spaced  " });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.macros[0].name).toBe("Spaced");
+  });
+
+  it("rejects empty or whitespace-only names", () => {
+    expect(addMacro([], { ...input, name: "" }).ok).toBe(false);
+    expect(addMacro([], { ...input, name: "   " }).ok).toBe(false);
+  });
+
+  it("rejects names longer than the max length", () => {
+    const longName = "x".repeat(MACRO_NAME_MAX_LENGTH + 1);
+    expect(addMacro([], { ...input, name: longName }).ok).toBe(false);
+  });
+
+  it("rejects duplicate names case-insensitively", () => {
+    const existing: Macro[] = [validMacro({ id: "1", name: "My Macro" })];
+    const result = addMacro(existing, { ...input, name: "MY MACRO" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/already exists/i);
+  });
+
+  it("rejects names that collide with built-ins (case-insensitive)", () => {
+    expect(addMacro([], { ...input, name: "last 30 days" }).ok).toBe(false);
+    expect(addMacro([], { ...input, name: "THIS MONTH" }).ok).toBe(false);
+  });
+
+  it("rejects new macro when at the cap", () => {
+    const existing: Macro[] = Array.from({ length: MACRO_LIMIT }, (_, i) =>
+      validMacro({ id: `${i}`, name: `User ${i}` })
+    );
+    const result = addMacro(existing, input);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/limit/i);
+  });
+
+  it("rejects invalid count / scope / unit", () => {
+    expect(addMacro([], { ...input, count: 0 }).ok).toBe(false);
+    expect(addMacro([], { ...input, count: NaN }).ok).toBe(false);
+    expect(addMacro([], { ...input, scope: "next" as never }).ok).toBe(false);
+    expect(addMacro([], { ...input, unit: "decades" as never }).ok).toBe(false);
+  });
+
+  it("does not mutate the input array", () => {
+    const existing: Macro[] = [];
+    addMacro(existing, input);
+    expect(existing).toHaveLength(0);
+  });
+});
+
+describe("deleteMacro", () => {
+  const existing: Macro[] = [
+    validMacro({ id: "a", name: "A" }),
+    validMacro({ id: "b", name: "B" }),
+  ];
+
+  it("removes the macro with the matching id", () => {
+    expect(deleteMacro(existing, "a").map((m) => m.id)).toEqual(["b"]);
+  });
+
+  it("is a no-op for an unknown id", () => {
+    expect(deleteMacro(existing, "zzz").map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const copy = [...existing];
+    deleteMacro(existing, "a");
+    expect(existing).toEqual(copy);
+  });
+});
+
+describe("loadMacros / saveMacros", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loadMacros returns [] when window is undefined (SSR / node env)", () => {
+    expect(loadMacros()).toEqual([]);
+  });
+
+  it("saveMacros does not throw when window is undefined", () => {
+    expect(() => saveMacros([validMacro()])).not.toThrow();
+  });
+
+  it("loadMacros returns [] when localStorage.getItem throws", () => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: () => {
+          throw new Error("blocked");
+        },
+        setItem: () => {},
+      },
+    });
+    expect(loadMacros()).toEqual([]);
+  });
+
+  it("saveMacros silently swallows localStorage.setItem errors", () => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error("quota exceeded");
+        },
+      },
+    });
+    expect(() => saveMacros([validMacro()])).not.toThrow();
+  });
+
+  it("round-trips macros through localStorage", () => {
+    const store: Record<string, string> = {};
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v;
+        },
+      },
+    });
+    const macros: Macro[] = [validMacro({ id: "1", name: "Saved" })];
+    saveMacros(macros);
+    expect(loadMacros()).toEqual(macros);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds four built-in one-click presets (Last 7 days, Last 30 days, This month, This year) and saveable user macros to the Date Range Picker's Quick Select panel. Closes #61.
- Macros are stored in `localStorage` under `dateRangeMacros` (not cookies — see #118 for the broader evaluation of cookie usage). Capped at 10; names trimmed, deduped case-insensitively (including against built-ins), max 50 chars.
- Saved-as form is inline (Enter/Escape supported); hover-reveals a delete affordance on each saved row. `Scope`/`Unit` types moved into the new `date-range-macros.ts` module as the schema source of truth. The picker's `onChange(from, to)` contract is unchanged, so both consumers (Transactions filter, Dashboard date filter) pick this up automatically with no code changes.

## Test plan

- [x] `npm run test:unit` — 116/116 pass (24 new in `date-range-macros.test.ts` covering parse defensiveness, dedupe, cap, delete, and localStorage-unavailable path)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] SSR smoke: `/dashboard` and `/dashboard/transactions` both 200
- [x] Click a built-in (Last 7 days / Last 30 days / This month / This year) → range applies, popover closes, URL updates with `?dateFrom=&dateTo=`
- [x] Configure builder, click **Save as…**, name and save → macro appears under "Saved"; reload → still present
- [x] Click a saved macro → range applies, popover closes, URL updates
- [x] Hover a saved macro → delete (x) shows; click → row disappears; reload → still gone
- [x] Save 10 macros → **Save as…** button disables with tooltip
- [x] Save same name as a built-in (case-insensitive) → inline error
- [x] Cross-page: save on `/dashboard/transactions`, open `/dashboard` picker → same macro visible
- [x] Private/incognito window → built-ins still work; save no-ops silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)