### PR TITLE
Clean up .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ﻿# IDE and tooling
-/.vs
+/.vscode
 /.claude
 
 # Root-level dependencies

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -2,13 +2,6 @@
 
 # dependencies
 /node_modules
-/.pnp
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/versions
 
 # testing
 /coverage
@@ -17,18 +10,12 @@
 /.next/
 /out/
 
-# production
-/build
-
 # misc
 .DS_Store
 *.pem
 
 # debug
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-.pnpm-debug.log*
 
 # env files — .env.local contains real credentials; .env.local.example is the committed template
 .env*


### PR DESCRIPTION
## Summary
- Fix `/.vs` → `/.vscode` in root `.gitignore`
- Remove Yarn Berry (`.pnp.*`, `.yarn/*`) entries from `app/.gitignore` — project uses npm
- Remove pnpm and yarn debug log patterns from `app/.gitignore`
- Remove `/build` from `app/.gitignore` — Next.js outputs to `.next/`, not `build/`

## Test plan
- [x] Confirm `git status` shows no unexpected untracked files after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)