### PR TITLE
Issue #123 - Centralize hardcoded reference-data IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ After this, `docker compose run --rm migrate` is a no-op on existing DBs (baseli
 
 The integration test `beforeAll` (in [`app/tests/integration/vitest-setup.ts`](app/tests/integration/vitest-setup.ts)) upserts the full production row set for `account_type_categories` (6 rows) and `transaction_types` (12 rows) before any test runs. This is a drift-correction safety net — the seed files above already populate these tables on first launch. No manual seed step is required.
 
+At runtime, [`/api/health`](app/app/api/health/route.ts) performs the equivalent check live: it verifies every ID referenced from [`app/lib/constants/reference-ids.ts`](app/lib/constants/reference-ids.ts) still resolves to its canonical seed-row name, and returns 503 with a `drift[]` array if any row is missing or renamed. See the Issue #123 changelog entry below for the response shape.
+
 ## Project Structure
 
 ```
@@ -234,7 +236,7 @@ finance-stack/
 │   ├── postcss.config.mjs                # PostCSS config (Tailwind CSS v4 plugin)
 │   ├── .env.local.example                # Template for app env vars (copy to .env.local)
 │   ├── app/                              # App Router — pages and layouts
-│   │   ├── api/health/route.ts           # Health check endpoint for Docker
+│   │   ├── api/health/route.ts           # Health check endpoint (Docker liveness + seed-row drift detection against SEED_REFERENCES)
 │   │   ├── layout.tsx                    # Root layout (fonts, ThemeProvider, Toaster)
 │   │   ├── globals.css                   # Global styles and Tailwind CSS theme variables
 │   │   ├── favicon.ico
@@ -338,6 +340,7 @@ finance-stack/
 │   │       ├── transaction-filters.tsx   # Label-less filter bar with date range, multi-select, amount
 │   │       └── transaction-columns.ts    # Shared ColumnKey type + visible-columns cookie helpers (server- and client-safe)
 │   ├── lib/                              # Shared libraries
+│   │   ├── constants/reference-ids.ts    # Centralized seed-row references (id + canonical name) and SEED_REFERENCES driver for the /api/health drift check
 │   │   ├── db/index.ts                   # Drizzle ORM client (PostgreSQL connection)
 │   │   ├── actions/utils.ts              # Shared ActionState type and buildFieldErrors() helper
 │   │   ├── actions/transaction.ts        # Server action for transaction submission
@@ -375,6 +378,7 @@ finance-stack/
 │   │       ├── setup.ts                  #   Global setup — asserts test DB URL
 │   │       ├── vitest-setup.ts           #   Per-test setup/teardown
 │   │       ├── actions/                  #   Server action tests (account, transaction)
+│   │       ├── api/                      #   API route tests (health drift check)
 │   │       └── queries/                  #   Query function tests (rebuild-balance, liabilities-drilldown)
 │   └── vitest.config.ts                  # Vitest configuration (unit + integration projects)
 ├── importer/                              # File import service
@@ -435,6 +439,11 @@ Data is persisted in Docker volumes and will be available on next startup.
 ## Updates
 
 ### 2026-05-21 — v0.1.3.1 (in progress)
+
+**Centralize hardcoded reference-data IDs ([Issue #123](https://github.com/aellington89/finance-stack/issues/123))**
+- Magic seed-row IDs that were duplicated across 6 files (`OPENING_BALANCE_TYPE_ID = 12`, `INCOME_TYPE_ID = 4`, `EXPENSE_TYPE_ID = 2`, `INVESTMENT_TYPE_ID = 10`, `WORK_EXPENSE_TYPE_ID = 5`, `REIMBURSEMENT_TYPE_ID = 6`, `NET_WORTH_EXCLUDED_CATEGORY_ID = 2`, `LIABILITY_CURRENT_CATEGORY_ID = 5`, `LIABILITY_NON_CURRENT_CATEGORY_ID = 6`, `OPENING_BALANCE_CATEGORY_ID = 6`) now live in a single source of truth at [`app/lib/constants/reference-ids.ts`](app/lib/constants/reference-ids.ts). Each constant is a `{ id, name } as const` record so the canonical seed-row name travels with the ID. Callsites in [`lib/actions/account.ts`](app/lib/actions/account.ts), [`lib/queries/accounting.ts`](app/lib/queries/accounting.ts), [`lib/queries/work-expenses.ts`](app/lib/queries/work-expenses.ts), [`lib/queries/dashboard.ts`](app/lib/queries/dashboard.ts), [`lib/queries/net-worth-drilldown.ts`](app/lib/queries/net-worth-drilldown.ts), and [`lib/queries/liability-categories.ts`](app/lib/queries/liability-categories.ts) now reference the records via `.id`. The legacy `LIABILITY_CURRENT_CATEGORY_ID` / `LIABILITY_NON_CURRENT_CATEGORY_ID` / `LIABILITY_CATEGORY_IDS` exports remain (derived from the new records) so [`liabilities-drilldown.ts`](app/lib/queries/liabilities-drilldown.ts) and the existing liability-categories unit test work unchanged. The user-data category arrays `DEBT_PAYMENT_CATEGORY_IDS` and `DEBT_INTEREST_CATEGORY_IDS` are intentionally untouched — they reference user-mutable `transaction_categories` rows, not seed lookups.
+- [`/api/health`](app/app/api/health/route.ts) is no longer a bare `SELECT 1` liveness probe — it also performs a per-request seed-drift check. For each seed table (`transaction_types`, `account_type_categories`, `transaction_categories`) it runs one batched `SELECT id, name … WHERE id IN (…)`, compares against the `SEED_REFERENCES` array in `reference-ids.ts`, and returns `503` with a `drift[]` array (`{ table, id, expected, actual }`) listing any missing or renamed rows. Happy path remains `{ status: "ok", db: "connected", seedData: "ok" }`. Note: the `OPENING_BALANCE_CATEGORY` ("Other", id=6) row lives in `transaction_categories`, which is editable via `/settings/categories` — renaming it through the UI will intentionally trip the drift check until [#109](https://github.com/aellington89/finance-stack/issues/109) lands row-level protection.
+- New integration test [`tests/integration/api/health.test.ts`](app/tests/integration/api/health.test.ts) covers both branches: the happy path returns 200 + `seedData: "ok"`, and renaming the "Opening Balance" `transaction_types` row produces a 503 whose `drift[]` entry exactly identifies the (table, id, expected, actual). The test restores the canonical name in `afterEach`, so a within-suite failure cannot leak to neighbouring tests — and the suite-wide `beforeAll` upsert in [`vitest-setup.ts`](app/tests/integration/vitest-setup.ts) is a second safety net.
 
 **Adopt a real Drizzle migration system ([Issue #121](https://github.com/aellington89/finance-stack/issues/121))**
 - `app/drizzle/schema.ts` is now the single source of truth for the database schema. The hand-maintained `init-db/schema.sql` (previously `pg_dump`ed from prod) and the commented-out `0000_initial_schema.sql` are deleted; `drizzle-kit pull` is demoted to inspection-only.

--- a/app/app/api/health/route.ts
+++ b/app/app/api/health/route.ts
@@ -1,14 +1,78 @@
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
+import { SEED_REFERENCES } from "@/lib/constants/reference-ids";
+
+export interface DriftEntry {
+  table: string;
+  id: number;
+  expected: string;
+  actual: string | null;
+}
+
+export async function checkSeedReferences(): Promise<DriftEntry[]> {
+  const drift: DriftEntry[] = [];
+
+  for (const group of SEED_REFERENCES) {
+    const ids = group.expected.map((r) => r.id);
+
+    const result = await db.execute(sql`
+      SELECT ${sql.identifier(group.idColumn)} AS id,
+             ${sql.identifier(group.nameColumn)} AS name
+      FROM ${sql.identifier(group.table)}
+      WHERE ${sql.identifier(group.idColumn)} IN (${sql.join(
+        ids.map((id) => sql`${id}`),
+        sql`, `,
+      )})
+    `);
+
+    const actualById = new Map<number, string>();
+    for (const row of result.rows as { id: number; name: string }[]) {
+      actualById.set(row.id, row.name);
+    }
+
+    for (const expected of group.expected) {
+      const actual = actualById.get(expected.id) ?? null;
+      if (actual !== expected.name) {
+        drift.push({
+          table: group.table,
+          id: expected.id,
+          expected: expected.name,
+          actual,
+        });
+      }
+    }
+  }
+
+  return drift;
+}
 
 export async function GET() {
   try {
     await db.execute(sql`SELECT 1`);
-    return Response.json({ status: "ok", db: "connected" });
   } catch {
     return Response.json(
       { status: "error", db: "disconnected" },
       { status: 503 },
     );
   }
+
+  let drift: DriftEntry[];
+  try {
+    drift = await checkSeedReferences();
+  } catch (err) {
+    console.error("Seed-reference health check failed:", err);
+    return Response.json(
+      { status: "error", db: "connected", seedData: "error" },
+      { status: 503 },
+    );
+  }
+
+  if (drift.length > 0) {
+    return Response.json(
+      { status: "error", db: "connected", seedData: "drift", drift },
+      { status: 503 },
+    );
+  }
+
+  return Response.json({ status: "ok", db: "connected", seedData: "ok" });
 }

--- a/app/lib/actions/account.ts
+++ b/app/lib/actions/account.ts
@@ -8,11 +8,10 @@ import { accountFormSchema } from "@/lib/validations/account";
 import { rebuildAccountBalance } from "@/lib/queries/rebuild-balance";
 import { eq, or } from "drizzle-orm";
 import { type ActionState, buildFieldErrors } from "@/lib/actions/utils";
-
-// transaction_types row: "Opening Balance" (seeded reference data — do not delete)
-const OPENING_BALANCE_TYPE_ID = 12;
-// transaction_categories row: "Other" (seeded reference data — do not delete)
-const OPENING_BALANCE_CATEGORY_ID = 6;
+import {
+  OPENING_BALANCE_TYPE,
+  OPENING_BALANCE_CATEGORY,
+} from "@/lib/constants/reference-ids";
 
 function revalidateAccountPaths() {
   revalidatePath("/accounts");
@@ -67,8 +66,8 @@ export async function createAccount(
           accountId: inserted.accountId,
           amount: data.initialBalance,
           relatedAccountId: null,
-          transactionTypeId: OPENING_BALANCE_TYPE_ID,
-          transactionCategoryId: OPENING_BALANCE_CATEGORY_ID,
+          transactionTypeId: OPENING_BALANCE_TYPE.id,
+          transactionCategoryId: OPENING_BALANCE_CATEGORY.id,
         });
 
         await rebuildAccountBalance(tx, inserted.accountId);

--- a/app/lib/constants/reference-ids.ts
+++ b/app/lib/constants/reference-ids.ts
@@ -1,0 +1,81 @@
+// Centralized seed-row references. Each constant pairs the row's primary key
+// with the canonical name shipped in init-db/seeds/shared-lookups.sql so the
+// /api/health route can verify the DB still matches by name (not just by ID).
+// Renaming a referenced row in the DB will trip the drift check.
+
+// ── transaction_types (seeded in init-db/seeds/shared-lookups.sql:27-41) ──
+
+export const EXPENSE_TYPE = { id: 2, name: "Expense" } as const;
+export const INCOME_TYPE = { id: 4, name: "Income" } as const;
+export const WORK_EXPENSE_TYPE = { id: 5, name: "Work Expense" } as const;
+export const WORK_EXPENSE_REIMBURSEMENT_TYPE = {
+  id: 6,
+  name: "Work Expense Reimbursement",
+} as const;
+export const INVESTMENT_TYPE = { id: 10, name: "Investment" } as const;
+export const OPENING_BALANCE_TYPE = { id: 12, name: "Opening Balance" } as const;
+
+// ── account_type_categories (seeded in init-db/seeds/shared-lookups.sql:17-25) ──
+
+export const RESTRICTED_ASSET_CATEGORY = {
+  id: 2,
+  name: "Restricted Asset",
+} as const;
+export const CURRENT_LIABILITY_CATEGORY = {
+  id: 5,
+  name: "Current Liability",
+} as const;
+export const NON_CURRENT_LIABILITY_CATEGORY = {
+  id: 6,
+  name: "Non-current Liability",
+} as const;
+
+// ── transaction_categories ────────────────────────────────────────────────
+// One seed-treated row used by account.ts opening-balance logic. NOTE: "Other"
+// is canonical for category id=6. Renaming it via /settings/categories will
+// intentionally trip the /api/health drift check.
+
+export const OPENING_BALANCE_CATEGORY = { id: 6, name: "Other" } as const;
+
+// ── Health-check driver ───────────────────────────────────────────────────
+// Each entry: which seed table to query and the rows we expect to find there
+// by (id, name). The /api/health route iterates this list once per request.
+
+export interface SeedReferenceGroup {
+  table: string;
+  idColumn: string;
+  nameColumn: string;
+  expected: ReadonlyArray<{ id: number; name: string }>;
+}
+
+export const SEED_REFERENCES: ReadonlyArray<SeedReferenceGroup> = [
+  {
+    table: "transaction_types",
+    idColumn: "transaction_type_id",
+    nameColumn: "transaction_type",
+    expected: [
+      EXPENSE_TYPE,
+      INCOME_TYPE,
+      WORK_EXPENSE_TYPE,
+      WORK_EXPENSE_REIMBURSEMENT_TYPE,
+      INVESTMENT_TYPE,
+      OPENING_BALANCE_TYPE,
+    ],
+  },
+  {
+    table: "account_type_categories",
+    idColumn: "account_type_category_id",
+    nameColumn: "account_type_category",
+    expected: [
+      RESTRICTED_ASSET_CATEGORY,
+      CURRENT_LIABILITY_CATEGORY,
+      NON_CURRENT_LIABILITY_CATEGORY,
+    ],
+  },
+  {
+    table: "transaction_categories",
+    idColumn: "transaction_category_id",
+    nameColumn: "transaction_category",
+    expected: [OPENING_BALANCE_CATEGORY],
+  },
+];

--- a/app/lib/queries/accounting.ts
+++ b/app/lib/queries/accounting.ts
@@ -1,5 +1,10 @@
 import { db } from "@/lib/db";
 import { sql, type SQL } from "drizzle-orm";
+import {
+  INCOME_TYPE,
+  EXPENSE_TYPE,
+  INVESTMENT_TYPE,
+} from "@/lib/constants/reference-ids";
 
 // ── Types ──
 
@@ -56,11 +61,7 @@ export interface AccountingFilters {
 
 // ── Helpers ──
 
-// Transaction type IDs (from seed data)
-const INCOME_TYPE_ID = 4;
-const EXPENSE_TYPE_ID = 2;
-const INVESTMENT_TYPE_ID = 10;
-const ACCOUNTING_TYPE_IDS = [INCOME_TYPE_ID, EXPENSE_TYPE_ID, INVESTMENT_TYPE_ID];
+const ACCOUNTING_TYPE_IDS = [INCOME_TYPE.id, EXPENSE_TYPE.id, INVESTMENT_TYPE.id];
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -168,9 +169,9 @@ export async function getAccountingTimeSeries(
       agg AS (
         SELECT
           ${sql.raw(groupExpr)} AS date,
-          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_income,
-          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_income,
+          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
+          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_investments
         FROM transactions t
         ${where}
         GROUP BY 1
@@ -204,9 +205,9 @@ export async function getAccountingTimeSeries(
       agg AS (
         SELECT
           ${sql.raw(groupExpr)} AS date,
-          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_income,
-          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_income,
+          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
+          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_investments
         FROM transactions t
         ${where}
         GROUP BY 1
@@ -246,9 +247,9 @@ export async function getAccountingPeriodTotals(
 
   const result = await db.execute(sql`
     SELECT
-      SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_income,
-      SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-      SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+      SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_income,
+      SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
+      SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_investments
     FROM transactions t
     ${where}
   `);
@@ -342,12 +343,12 @@ export async function getAccountingToDateComparison(
         (date_trunc(${sql.raw(`'${truncation}'`)}, ${refDate}::date) - interval '1 day')::date AS prev_end
     )
     SELECT
-      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS cur_income,
-      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS prev_income,
-      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS cur_expenses,
-      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS prev_expenses,
-      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS cur_investments,
-      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS prev_investments,
+      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS cur_income,
+      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS prev_income,
+      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS cur_expenses,
+      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS prev_expenses,
+      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS cur_investments,
+      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS prev_investments,
       MIN(${sql.raw(curLabelExpr)}) AS cur_label,
       MIN(${sql.raw(prevLabelExpr)}) AS prev_label
     FROM transactions t
@@ -376,7 +377,7 @@ export async function getExpenseCategoryBreakdown(
   filters: AccountingFilters
 ): Promise<CategoryBreakdown[]> {
   const conditions = buildFilterConditions(filters);
-  conditions.push(sql.raw(`t.transaction_type_id = ${EXPENSE_TYPE_ID}`));
+  conditions.push(sql.raw(`t.transaction_type_id = ${EXPENSE_TYPE.id}`));
   const where = whereFromConditions(conditions);
 
   const result = await db.execute(sql`
@@ -425,9 +426,9 @@ export async function getAccountingMonthlyAverages(
     WITH monthly AS (
       SELECT
         date_trunc('month', t.transaction_date) AS month,
-        SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS income,
-        SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS expenses,
-        SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS investments
+        SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS income,
+        SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS expenses,
+        SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS investments
       FROM transactions t
       WHERE t.transaction_date >= date_trunc('month', CURRENT_DATE) - interval '12 months'
         AND t.transaction_date < date_trunc('month', CURRENT_DATE)

--- a/app/lib/queries/dashboard.ts
+++ b/app/lib/queries/dashboard.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { sql, type SQL } from "drizzle-orm";
+import { RESTRICTED_ASSET_CATEGORY } from "@/lib/constants/reference-ids";
 
 export interface TimeSeriesPoint {
   date: string;
@@ -13,9 +14,6 @@ export interface NetWorthSummary {
   totalLiabilities: number;
   netWorth: number;
 }
-
-// Category IDs
-const NET_WORTH_EXCLUDED_CATEGORY_ID = 2; // Restricted Asset excluded from net worth
 
 export async function getCurrentNetWorth(): Promise<NetWorthSummary> {
   // All three metrics use today's cumulative_balance snapshot.
@@ -33,7 +31,7 @@ export async function getCurrentNetWorth(): Promise<NetWorthSummary> {
         THEN abh.cumulative_balance ELSE 0
       END) AS total_liabilities,
       SUM(CASE
-        WHEN at.account_type_category_id != ${NET_WORTH_EXCLUDED_CATEGORY_ID}
+        WHEN at.account_type_category_id != ${RESTRICTED_ASSET_CATEGORY.id}
         THEN abh.cumulative_balance ELSE 0
       END) AS net_worth
     FROM account_balance_history abh
@@ -81,7 +79,7 @@ export async function getNetWorthTimeSeries(
         THEN abh.cumulative_balance ELSE 0
       END) AS total_liabilities,
       SUM(CASE
-        WHEN at.account_type_category_id != ${NET_WORTH_EXCLUDED_CATEGORY_ID}
+        WHEN at.account_type_category_id != ${RESTRICTED_ASSET_CATEGORY.id}
         THEN abh.cumulative_balance ELSE 0
       END) AS net_worth
     FROM account_balance_history abh

--- a/app/lib/queries/liability-categories.ts
+++ b/app/lib/queries/liability-categories.ts
@@ -27,8 +27,13 @@
 // fix needs a "released"/standard-mapping concept on transaction_categories
 // so user-owned rows can opt into these aggregates. Track separately.
 
-export const LIABILITY_CURRENT_CATEGORY_ID = 5;
-export const LIABILITY_NON_CURRENT_CATEGORY_ID = 6;
+import {
+  CURRENT_LIABILITY_CATEGORY,
+  NON_CURRENT_LIABILITY_CATEGORY,
+} from "@/lib/constants/reference-ids";
+
+export const LIABILITY_CURRENT_CATEGORY_ID = CURRENT_LIABILITY_CATEGORY.id;
+export const LIABILITY_NON_CURRENT_CATEGORY_ID = NON_CURRENT_LIABILITY_CATEGORY.id;
 
 export const LIABILITY_CATEGORY_IDS = [
   LIABILITY_CURRENT_CATEGORY_ID,

--- a/app/lib/queries/net-worth-drilldown.ts
+++ b/app/lib/queries/net-worth-drilldown.ts
@@ -1,8 +1,6 @@
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
-
-// Category IDs
-const NET_WORTH_EXCLUDED_CATEGORY_ID = 2; // Restricted Asset excluded from net worth
+import { RESTRICTED_ASSET_CATEGORY } from "@/lib/constants/reference-ids";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -87,7 +85,7 @@ export async function getNetWorthWaterfall(
     JOIN account_types at ON at.account_type_id = a.account_type_id
     JOIN account_type_categories atc
       ON atc.account_type_category_id = at.account_type_category_id
-    WHERE atc.account_type_category_id != ${NET_WORTH_EXCLUDED_CATEGORY_ID}
+    WHERE atc.account_type_category_id != ${RESTRICTED_ASSET_CATEGORY.id}
       AND abh.balance_date IN (${dateFrom}::date, ${endDate}::date)
     GROUP BY atc.account_type_category_id, atc.account_type_category
     ORDER BY atc.account_type_category_id
@@ -148,7 +146,7 @@ export async function getNetWorthDrivers(
     JOIN account_types at ON at.account_type_id = a.account_type_id
     JOIN account_type_categories atc
       ON atc.account_type_category_id = at.account_type_category_id
-    WHERE atc.account_type_category_id != ${NET_WORTH_EXCLUDED_CATEGORY_ID}
+    WHERE atc.account_type_category_id != ${RESTRICTED_ASSET_CATEGORY.id}
       AND abh.balance_date IN (${dateFrom}::date, ${endDate}::date)
     GROUP BY
       atc.account_type_category_id, atc.account_type_category,
@@ -281,7 +279,7 @@ export async function getNetWorthTrendDecomposition(
   dateTo?: string
 ): Promise<DecompositionPoint[]> {
   const conditions = [
-    sql`atc.account_type_category_id != ${NET_WORTH_EXCLUDED_CATEGORY_ID}`,
+    sql`atc.account_type_category_id != ${RESTRICTED_ASSET_CATEGORY.id}`,
   ];
 
   if (dateFrom) {

--- a/app/lib/queries/work-expenses.ts
+++ b/app/lib/queries/work-expenses.ts
@@ -1,6 +1,10 @@
 import { db } from "@/lib/db";
 import { sql, type SQL } from "drizzle-orm";
 import type { CategoryBreakdown } from "@/lib/queries/accounting";
+import {
+  WORK_EXPENSE_TYPE,
+  WORK_EXPENSE_REIMBURSEMENT_TYPE,
+} from "@/lib/constants/reference-ids";
 
 // ── Types ──
 
@@ -23,9 +27,10 @@ export interface WorkExpenseTimeSeriesPoint {
 
 // ── Constants ──
 
-const WORK_EXPENSE_TYPE_ID = 5;
-const REIMBURSEMENT_TYPE_ID = 6;
-const WORK_EXPENSE_TYPE_IDS = [WORK_EXPENSE_TYPE_ID, REIMBURSEMENT_TYPE_ID];
+const WORK_EXPENSE_TYPE_IDS = [
+  WORK_EXPENSE_TYPE.id,
+  WORK_EXPENSE_REIMBURSEMENT_TYPE.id,
+];
 
 // ── Helpers ──
 
@@ -64,8 +69,8 @@ export async function getWorkExpenseTotals(
 
   const result = await db.execute(sql`
     SELECT
-      SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_work_expenses,
-      SUM(CASE WHEN t.transaction_type_id = ${REIMBURSEMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_reimbursements
+      SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_work_expenses,
+      SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_REIMBURSEMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_reimbursements
     FROM transactions t
     ${where}
   `);
@@ -97,8 +102,8 @@ export async function getWorkExpenseTimeSeries(
     agg AS (
       SELECT
         date_trunc('month', t.transaction_date)::date AS date,
-        SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-        SUM(CASE WHEN t.transaction_type_id = ${REIMBURSEMENT_TYPE_ID} THEN ABS(t.amount) ELSE 0 END) AS total_reimbursements
+        SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
+        SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_REIMBURSEMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_reimbursements
       FROM transactions t
       WHERE t.transaction_date >= date_trunc('month', ${dateFrom}::date)::date
         AND t.transaction_date <= ${dateTo}::date
@@ -127,7 +132,7 @@ export async function getWorkExpenseCategoryBreakdown(
   filters: WorkExpenseFilters
 ): Promise<CategoryBreakdown[]> {
   const conditions = buildDateConditions(filters);
-  conditions.push(sql.raw(`t.transaction_type_id = ${WORK_EXPENSE_TYPE_ID}`));
+  conditions.push(sql.raw(`t.transaction_type_id = ${WORK_EXPENSE_TYPE.id}`));
   const where = whereFromConditions(conditions);
 
   const result = await db.execute(sql`

--- a/app/tests/integration/api/health.test.ts
+++ b/app/tests/integration/api/health.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { db } from "@/lib/db";
+import { sql } from "drizzle-orm";
+import { GET } from "@/app/api/health/route";
+import { OPENING_BALANCE_TYPE } from "@/lib/constants/reference-ids";
+
+async function restoreOpeningBalanceTypeName() {
+  await db.execute(sql`
+    UPDATE transaction_types
+    SET transaction_type = ${OPENING_BALANCE_TYPE.name}
+    WHERE transaction_type_id = ${OPENING_BALANCE_TYPE.id}
+  `);
+}
+
+describe("GET /api/health", () => {
+  afterEach(restoreOpeningBalanceTypeName);
+
+  it("returns 200 with seedData: ok when seed rows are intact", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "ok",
+      db: "connected",
+      seedData: "ok",
+    });
+  });
+
+  it("returns 503 with a drift entry when a seed row has been renamed", async () => {
+    await db.execute(sql`
+      UPDATE transaction_types
+      SET transaction_type = 'RENAMED_BY_TEST'
+      WHERE transaction_type_id = ${OPENING_BALANCE_TYPE.id}
+    `);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe("error");
+    expect(body.seedData).toBe("drift");
+    expect(body.drift).toContainEqual({
+      table: "transaction_types",
+      id: OPENING_BALANCE_TYPE.id,
+      expected: OPENING_BALANCE_TYPE.name,
+      actual: "RENAMED_BY_TEST",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Magic seed-row IDs duplicated across 6 files now live in a single source of truth at `app/lib/constants/reference-ids.ts` as `{ id, name } as const` records. Callsites reference `.id`; the canonical name travels with the ID into both query callsites and the health check.
- `/api/health` extended with a per-request seed-drift check: one batched `SELECT id, name WHERE id IN (...)` per seed table (`transaction_types`, `account_type_categories`, `transaction_categories`), compared against `SEED_REFERENCES`. Missing or renamed rows yield 503 with a `drift[]` array (`{ table, id, expected, actual }`). Happy path returns `{ status: "ok", db: "connected", seedData: "ok" }`.
- Legacy `LIABILITY_CURRENT_CATEGORY_ID` / `LIABILITY_NON_CURRENT_CATEGORY_ID` / `LIABILITY_CATEGORY_IDS` exports preserved as derived re-exports — `liabilities-drilldown.ts` and the existing liability-categories unit test work unchanged.

Closes #123. Follow-up gate filed as #155 (CI assertion that `SEED_REFERENCES` names match `init-db/seeds/shared-lookups.sql` to prevent code-side drift masking).

## Scope expanded during planning

The issue listed 4 files; planning surfaced two more carrying the same anti-pattern (`work-expenses.ts`, `liability-categories.ts`). All 6 are in this PR. The user-data `DEBT_PAYMENT_CATEGORY_IDS` / `DEBT_INTEREST_CATEGORY_IDS` arrays were intentionally left untouched — they reference user-mutable `transaction_categories` rows, not seed lookups.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 116/116 passed (covers liability-categories back-compat re-exports)
- [x] `npm run test:integration` — 72/72 passed, including 2 new `/api/health` tests:
  - Returns 200 + `seedData: "ok"` when seed rows are intact
  - Returns 503 + `drift[]` entry naming the offending row when "Opening Balance" is renamed
- [x] Grep sweep — no stale `*_TYPE_ID` / `*_CATEGORY_ID` literals remain at any callsite
- [ ] Manual smoke against a dev DB: `curl /api/health` returns 200; rename `transaction_types.transaction_type` for id=12 in `Finances`; `curl /api/health` returns 503 with the expected drift entry; restore

## Notes for reviewer

- `OPENING_BALANCE_CATEGORY` ("Other", id=6) lives in user-editable `transaction_categories`. Renaming category id=6 via `/settings/categories` will *intentionally* trip the health check. Row-level protection is tracked in #109.
- `sql.identifier` (drizzle-orm 0.45.1) is used for table/column quoting in the health route — verified available in the pinned version.
- Three sequential `SELECT ... WHERE id IN (...)` against tiny seed tables, all PK index scans. Sub-millisecond; safe to run on every `/api/health` hit. If `/api/health` becomes an external load-balancer probe post-#120/#130, splitting into liveness + drift endpoints is worth re-evaluating (notes left on both issues).

Planning detail and AC verification on the issue: https://github.com/aellington89/finance-stack/issues/123

🤖 Generated with [Claude Code](https://claude.com/claude-code)