### PR TITLE
Issue #155 - Add CI gate: SEED_REFERENCES names must match shared-lookups.sql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
             exit 1
           fi
 
+      - name: Seed reference gate
+        run: npm run check:seed-references
+
       - name: Lint
         run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ finance-stack/
 │   │           ├── _journal.json         # Ordered list of applied migrations (idx, tag, breakpoints)
 │   │           └── 0000_snapshot.json    # Full schema snapshot at the 0000_baseline migration
 │   ├── scripts/
-│   │   └── migrate-and-seed.sh           # Entrypoint for the `migrate` Compose service (drizzle-kit migrate + seed)
+│   │   ├── migrate-and-seed.sh           # Entrypoint for the `migrate` Compose service (drizzle-kit migrate + seed)
+│   │   ├── check-seed-references.ts       # CI gate: SEED_REFERENCES (id, name) must match shared-lookups.sql (#155)
+│   │   └── seed-reference-check.ts        # Pure parse + diff helpers backing the gate (unit-tested)
 │   ├── hooks/
 │   │   └── use-mobile.ts                 # Mobile breakpoint detection hook (used by sidebar)
 │   ├── components/
@@ -379,6 +381,7 @@ finance-stack/
 │   │   │   ├── validations/              #   Zod schema tests (account, transaction, categories)
 │   │   │   ├── actions/                  #   Action utility tests (buildFieldErrors)
 │   │   │   ├── components/               #   Component function tests (waterfall transform, liquidity, asset perf, debt-mix, debt-waterfall, liability perf, date-range macros)
+│   │   │   ├── scripts/                  #   Build-tooling tests (seed-reference gate parse + diff)
 │   │   │   └── lib/                      #   Library utility tests
 │   │   │       ├── utils.test.ts         #     cn() class-merge helper
 │   │   │       ├── forms/                #     Form helpers (transaction post-submit state)
@@ -395,7 +398,7 @@ finance-stack/
 │   ├── poll.py                            # Polling loop and parser dispatcher (committed)
 │   └── parsers/                           # One module per import type (gitignored)
 ├── imports/                               # Drop folders — one per import type (gitignored)
-├── .github/workflows/ci.yml             # CI: lint + unit tests + integration tests on push/PR
+├── .github/workflows/ci.yml             # CI: schema-drift + seed-reference gates, lint, unit + integration tests
 ├── .vscode/extensions.json              # Recommended VS Code extensions for this project
 ├── init-db/
 │   ├── 01-create-databases.sh            # First-run DB + Metabase role creation only (auto-runs on empty data dir)
@@ -448,7 +451,13 @@ Data is persisted in Docker volumes and will be available on next startup.
 
 ## Updates
 
-### 2026-05-21 — v0.1.3.1 (in progress)
+### 2026-06-05 — v0.1.3.1 (in progress)
+
+**Add CI gate: SEED_REFERENCES names must match shared-lookups.sql ([Issue #155](https://github.com/aellington89/finance-stack/issues/155))**
+- #123's [`/api/health`](app/app/api/health/route.ts) drift check catches *DB-side* drift (the live DB diverging from code) but not *code-side* drift: renaming a row in [`init-db/seeds/shared-lookups.sql`](init-db/seeds/shared-lookups.sql) and silencing the resulting health failure by editing [`reference-ids.ts`](app/lib/constants/reference-ids.ts) to match leaves both checks green while code and seed silently disagree about a clean install. A build-time gate closes that gap.
+- New [`app/scripts/check-seed-references.ts`](app/scripts/check-seed-references.ts) imports the real `SEED_REFERENCES` and cross-checks each `(table, id, name)` against the matching `INSERT … VALUES` row parsed from `shared-lookups.sql`, failing with a `::error::` line naming `(table, id, code-side name, seed-side name)` — mirroring the existing Schema drift gate's annotation + remediation-hint style. The parse/diff logic lives in side-effect-free [`app/scripts/seed-reference-check.ts`](app/scripts/seed-reference-check.ts) so it is unit-testable.
+- **Directional + fail-closed:** every constant must match the seed, but unreferenced seed rows are fine; a referenced table with no `INSERT` block fails the gate *unless* it is in an explicit allowed-absent set. `transaction_categories` (the `OPENING_BALANCE_CATEGORY` "Other" row) is the sole allowed-absent table — it is intentionally not in `shared-lookups.sql` (row-level protection tracked in [#109](https://github.com/aellington89/finance-stack/issues/109)).
+- Wired into [`.github/workflows/ci.yml`](.github/workflows/ci.yml) as a new "Seed reference gate" step beside the Schema drift gate (no DB needed) and runnable locally via `npm run check:seed-references`; adds `tsx` as a devDependency so the gate can import the `@/`-aliased TS source directly. New unit tests in [`tests/unit/scripts/seed-reference-check.test.ts`](app/tests/unit/scripts/seed-reference-check.test.ts) cover the deliberate rename-trips-the-gate case plus missing-row, fail-closed missing-table, the allowlist skip, `''`-unescaping, and the directional extra-rows case.
 
 **Fix baseline re-application on adopted DBs ([Issue #157](https://github.com/aellington89/finance-stack/issues/157))**
 - `drizzle-kit migrate` was re-running `0000_baseline.sql` on any DB that adopted the existing schema via the README's one-time `INSERT INTO drizzle.__drizzle_migrations` (the real `Finances` and `Finances_Test`), failing with `relation "account_balance_history" already exists` (`42P07`) and blocking every new migration (e.g. #127's indexes). Root cause: drizzle treats a migration as applied only if the most-recent stored `created_at >= ` the journal `when`, but the adoption procedure recorded `created_at = now()` (wall-clock at adoption), which landed ~2.6h *before* the baseline journal `when` (`1779422763028`) — so drizzle considered the baseline pending. Fresh DBs (CI, new clones) were never affected.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -41,6 +41,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
+        "tsx": "^4.22.4",
         "typescript": "^5",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.2"
@@ -12093,6 +12094,509 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
     "start": "next start -p 3001",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
+    "check:seed-references": "tsx scripts/check-seed-references.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -51,6 +52,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
+    "tsx": "^4.22.4",
     "typescript": "^5",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.2"

--- a/app/scripts/check-seed-references.ts
+++ b/app/scripts/check-seed-references.ts
@@ -1,0 +1,51 @@
+// CI gate (and `npm run check:seed-references`): asserts every SEED_REFERENCES
+// (table, id, name) matches the matching row in init-db/seeds/shared-lookups.sql.
+// This catches *code-side* drift the runtime /api/health check cannot — e.g. a
+// seed rename "fixed" by editing reference-ids.ts to match, which silences the
+// health check while code and seed silently disagree about a clean install.
+// Complements #123; see the Issue #155 changelog entry. Mirrors the Schema
+// drift gate's ::error:: annotation + remediation-hint style.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SEED_REFERENCES } from "@/lib/constants/reference-ids";
+import { findSeedReferenceMismatches, type Mismatch } from "@/scripts/seed-reference-check";
+
+// This file lives at app/scripts/, so ../../ is the repo root.
+const SEED_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../init-db/seeds/shared-lookups.sql",
+);
+
+function formatMismatch(m: Mismatch): string {
+  switch (m.reason) {
+    case "name":
+      return `::error::Seed reference drift: ${m.table} id=${m.id} — code expects "${m.expected}" but shared-lookups.sql has "${m.actual}"`;
+    case "missing-row":
+      return `::error::Seed reference drift: ${m.table} id=${m.id} — code expects "${m.expected}" but no row with that id exists in shared-lookups.sql`;
+    case "missing-table":
+      return `::error::Seed reference drift: table "${m.table}" is referenced by SEED_REFERENCES but no INSERT block exists in shared-lookups.sql (and it is not in the allowed-absent list)`;
+  }
+}
+
+function main(): void {
+  const mismatches = findSeedReferenceMismatches(SEED_REFERENCES, readFileSync(SEED_PATH, "utf8"));
+
+  if (mismatches.length === 0) {
+    console.log("✓ Seed reference gate: SEED_REFERENCES matches init-db/seeds/shared-lookups.sql");
+    return;
+  }
+
+  for (const m of mismatches) console.error(formatMismatch(m));
+  console.error("");
+  console.error(
+    "code-side and seed-side reference data diverged. Reconcile init-db/seeds/shared-lookups.sql " +
+      "and app/lib/constants/reference-ids.ts so each (id, name) agrees, then re-run " +
+      "`npm run check:seed-references`.",
+  );
+  process.exit(1);
+}
+
+main();

--- a/app/scripts/seed-reference-check.ts
+++ b/app/scripts/seed-reference-check.ts
@@ -1,0 +1,95 @@
+// Pure parse + diff helpers backing the seed-reference CI gate
+// (app/scripts/check-seed-references.ts). Kept side-effect-free so the unit
+// suite can exercise the logic against inline SQL fixtures without touching the
+// filesystem or the process exit code.
+//
+// The gate is directional: every SEED_REFERENCES (table, id, name) must match
+// the matching INSERT row in init-db/seeds/shared-lookups.sql, but unreferenced
+// seed rows are fine. It is also fail-closed — a referenced table with no INSERT
+// block in the seed trips the gate unless it is intentionally seeded elsewhere
+// (see TABLES_ALLOWED_ABSENT).
+
+import type { SeedReferenceGroup } from "@/lib/constants/reference-ids";
+
+// Tables referenced by SEED_REFERENCES that are deliberately NOT in
+// shared-lookups.sql. transaction_categories is seeded per-database elsewhere
+// (finances-test-mock-data.sql for the test DB; production has no seed for it),
+// so it has no row in the shared file — its row-level protection is tracked in
+// #109. Any other absent table is treated as a bug and fails the gate.
+export const TABLES_ALLOWED_ABSENT = new Set<string>(["transaction_categories"]);
+
+export type MismatchReason = "name" | "missing-row" | "missing-table";
+
+export interface Mismatch {
+  table: string;
+  // id/expected are null only for a whole-table miss (reason "missing-table").
+  id: number | null;
+  expected: string | null;
+  // actual is the seed-side name for "name", and null for "missing-row" /
+  // "missing-table".
+  actual: string | null;
+  reason: MismatchReason;
+}
+
+// Parse the `INSERT INTO <table> (...) [OVERRIDING SYSTEM VALUE] VALUES
+// (id, 'name'), ... ON CONFLICT ...` blocks from a hand-authored seed file into
+// table -> (id -> name). UPDATE / SELECT setval statements carry no
+// `VALUES ... ON CONFLICT` and are ignored. Names are single-quoted with SQL ''
+// escaping; the seed file is hand-authored and stable, so per-block regex is
+// sufficient (see #155).
+export function parseSeedRows(sql: string): Map<string, Map<number, string>> {
+  const tables = new Map<string, Map<number, string>>();
+  // [\s\S]*? (rather than the `s`/dotAll flag) keeps the multi-line VALUES body
+  // match compatible with the ES2017 tsconfig target.
+  const blockRe =
+    /INSERT\s+INTO\s+(\w+)\s*\([^)]*\)\s*(?:OVERRIDING\s+SYSTEM\s+VALUE\s+)?VALUES\s*([\s\S]*?)\s*ON\s+CONFLICT/gi;
+  const rowRe = /\(\s*(\d+)\s*,\s*'((?:[^']|'')*)'\s*\)/g;
+
+  for (const block of sql.matchAll(blockRe)) {
+    const table = block[1].toLowerCase();
+    const rows = tables.get(table) ?? new Map<number, string>();
+    for (const row of block[2].matchAll(rowRe)) {
+      rows.set(Number(row[1]), row[2].replace(/''/g, "'"));
+    }
+    tables.set(table, rows);
+  }
+
+  return tables;
+}
+
+// Cross-check each SEED_REFERENCES (table, id, name) against the parsed seed.
+// Returns one Mismatch per divergence; an empty array means code and seed agree.
+export function findSeedReferenceMismatches(
+  seedReferences: ReadonlyArray<SeedReferenceGroup>,
+  sql: string,
+): Mismatch[] {
+  const seed = parseSeedRows(sql);
+  const mismatches: Mismatch[] = [];
+
+  for (const group of seedReferences) {
+    const seedRows = seed.get(group.table.toLowerCase());
+
+    if (!seedRows) {
+      if (TABLES_ALLOWED_ABSENT.has(group.table.toLowerCase())) continue;
+      mismatches.push({
+        table: group.table,
+        id: null,
+        expected: null,
+        actual: null,
+        reason: "missing-table",
+      });
+      continue;
+    }
+
+    for (const { id, name } of group.expected) {
+      const actual = seedRows.get(id);
+      if (actual === undefined) {
+        mismatches.push({ table: group.table, id, expected: name, actual: null, reason: "missing-row" });
+      } else if (actual !== name) {
+        mismatches.push({ table: group.table, id, expected: name, actual, reason: "name" });
+      }
+    }
+  }
+
+  return mismatches;
+}

--- a/app/tests/unit/scripts/seed-reference-check.test.ts
+++ b/app/tests/unit/scripts/seed-reference-check.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import type { SeedReferenceGroup } from "@/lib/constants/reference-ids";
+import {
+  parseSeedRows,
+  findSeedReferenceMismatches,
+  TABLES_ALLOWED_ABSENT,
+} from "@/scripts/seed-reference-check";
+
+// A representative slice of shared-lookups.sql: two INSERT blocks plus the
+// trailing setval/UPDATE noise the parser must ignore.
+const SEED = `
+INSERT INTO account_type_categories (account_type_category_id, account_type_category)
+OVERRIDING SYSTEM VALUE VALUES
+    (1, 'Current Asset'),
+    (2, 'Restricted Asset'),
+    (5, 'Current Liability')
+ON CONFLICT (account_type_category_id) DO NOTHING;
+
+INSERT INTO transaction_types (transaction_type_id, transaction_type)
+OVERRIDING SYSTEM VALUE VALUES
+    (2, 'Expense'),
+    (12, 'Opening Balance')
+ON CONFLICT (transaction_type_id) DO NOTHING;
+
+SELECT setval(pg_get_serial_sequence('transaction_types', 'transaction_type_id'), 12);
+
+UPDATE account_types SET liquidity_class = 'liquid'
+    WHERE liquidity_class IS NULL AND account_type IN ('Checking Account', 'Savings Account');
+`;
+
+// Minimal SeedReferenceGroup factory — the gate only reads `table` and `expected`.
+function group(table: string, expected: Array<{ id: number; name: string }>): SeedReferenceGroup {
+  return { table, idColumn: "id", nameColumn: "name", expected };
+}
+
+describe("parseSeedRows", () => {
+  it("parses each INSERT block into table -> (id -> name)", () => {
+    const seed = parseSeedRows(SEED);
+    expect(seed.get("transaction_types")?.get(2)).toBe("Expense");
+    expect(seed.get("transaction_types")?.get(12)).toBe("Opening Balance");
+    expect([...(seed.get("account_type_categories")?.keys() ?? [])]).toEqual([1, 2, 5]);
+  });
+
+  it("ignores UPDATE and SELECT setval statements", () => {
+    const seed = parseSeedRows(SEED);
+    expect([...seed.keys()].sort()).toEqual(["account_type_categories", "transaction_types"]);
+  });
+
+  it("unescapes doubled single quotes in names", () => {
+    const seed = parseSeedRows(
+      `INSERT INTO t (id, name) VALUES (1, 'Children''s Fund') ON CONFLICT DO NOTHING;`,
+    );
+    expect(seed.get("t")?.get(1)).toBe("Children's Fund");
+  });
+});
+
+describe("findSeedReferenceMismatches", () => {
+  it("returns no mismatches when code matches the seed", () => {
+    const refs = [
+      group("account_type_categories", [{ id: 2, name: "Restricted Asset" }]),
+      group("transaction_types", [{ id: 12, name: "Opening Balance" }]),
+    ];
+    expect(findSeedReferenceMismatches(refs, SEED)).toEqual([]);
+  });
+
+  it("treats unreferenced seed rows as fine (directional)", () => {
+    // SEED has ids 1 and 5 in account_type_categories that no constant references.
+    const refs = [group("account_type_categories", [{ id: 2, name: "Restricted Asset" }])];
+    expect(findSeedReferenceMismatches(refs, SEED)).toEqual([]);
+  });
+
+  it("flags a renamed row — the deliberate code/seed-disagree case", () => {
+    const refs = [group("transaction_types", [{ id: 2, name: "Expenses" }])];
+    expect(findSeedReferenceMismatches(refs, SEED)).toEqual([
+      { table: "transaction_types", id: 2, expected: "Expenses", actual: "Expense", reason: "name" },
+    ]);
+  });
+
+  it("flags a referenced id with no matching seed row", () => {
+    const refs = [group("transaction_types", [{ id: 99, name: "Nonexistent" }])];
+    expect(findSeedReferenceMismatches(refs, SEED)).toEqual([
+      { table: "transaction_types", id: 99, expected: "Nonexistent", actual: null, reason: "missing-row" },
+    ]);
+  });
+
+  it("skips a table that is intentionally absent from shared-lookups.sql", () => {
+    expect(TABLES_ALLOWED_ABSENT.has("transaction_categories")).toBe(true);
+    const refs = [group("transaction_categories", [{ id: 6, name: "Other" }])];
+    expect(findSeedReferenceMismatches(refs, SEED)).toEqual([]);
+  });
+
+  it("fails closed when a referenced table is missing and not allowlisted", () => {
+    // transaction_types block removed from the seed; the constant still references it.
+    const seedWithoutTxTypes = `
+INSERT INTO account_type_categories (account_type_category_id, account_type_category)
+OVERRIDING SYSTEM VALUE VALUES (2, 'Restricted Asset')
+ON CONFLICT (account_type_category_id) DO NOTHING;`;
+    const refs = [group("transaction_types", [{ id: 2, name: "Expense" }])];
+    expect(findSeedReferenceMismatches(refs, seedWithoutTxTypes)).toEqual([
+      { table: "transaction_types", id: null, expected: null, actual: null, reason: "missing-table" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a build-time CI gate ([#155](https://github.com/aellington89/finance-stack/issues/155)) that asserts every `SEED_REFERENCES` `(table, id, name)` in `app/lib/constants/reference-ids.ts` matches the corresponding `INSERT ... VALUES` row in `init-db/seeds/shared-lookups.sql`. It closes the *code-side* drift blind spot in #123's runtime `/api/health` check: a seed rename "fixed" by editing `reference-ids.ts` to match would otherwise leave both checks green while the code and seed silently disagree about what a clean install contains.

Mirrors the existing **Schema drift gate** (same `::error::` annotation + remediation hint) and is runnable locally via `npm run check:seed-references`.

## Behavior

- **Directional** — every constant must match the seed, but unreferenced seed rows are fine.
- **Fail-closed** — a referenced table with no `INSERT` block fails the gate *unless* it's in an explicit allowlist. `transaction_categories` (the `OPENING_BALANCE_CATEGORY` "Other" row) is the sole allowed-absent table; it's intentionally not in `shared-lookups.sql` (row-level protection tracked in #109).
- **Failure output** names `(table, id, code-side name, seed-side name)`, e.g.:
  > `::error::Seed reference drift: transaction_types id=2 — code expects "Expense" but shared-lookups.sql has "Expenses"`

## Changes

| File | Change |
|---|---|
| `app/scripts/seed-reference-check.ts` *(new)* | Pure, side-effect-free `parseSeedRows()` + `findSeedReferenceMismatches()` + `TABLES_ALLOWED_ABSENT` |
| `app/scripts/check-seed-references.ts` *(new)* | Executable gate — reads the seed, prints `::error::` per mismatch + remediation hint, exits non-zero |
| `app/tests/unit/scripts/seed-reference-check.test.ts` *(new)* | 9 cases: deliberate rename, missing-row, fail-closed missing-table, allowlist skip, `''`-unescaping, directional extra rows |
| `.github/workflows/ci.yml` | New "Seed reference gate" step beside the Schema drift gate (no DB needed) |
| `app/package.json` | `check:seed-references` script + `tsx` devDependency |
| `README.md` | Project-structure tree + Issue #155 changelog entry |

## Verification

- `npm run check:seed-references` — passes on a clean tree (exit 0); renaming a seed row fails with exit 1 and the named divergence, then was reverted.
- `npm run typecheck`, `npm run lint`, `npm run test:unit` (125 tests, incl. 9 new) — all pass.

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
