### PR TITLE
Issue #134 - Extract amountColorClass + shared SQL aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ finance-stack/
 │   │   ├── actions/transaction.ts        # Server action for transaction submission
 │   │   ├── actions/account.ts            # Server actions for account create, update, delete
 │   │   ├── actions/categories.ts         # Server actions for category/type create, update, delete
+│   │   ├── queries/_aggregates.ts        # Shared SQL aggregation fragments (sum-by-type, balance-at-date)
 │   │   ├── queries/accounts.ts           # Account balance queries (ROLLUP aggregation)
 │   │   ├── queries/accounting.ts         # Accounting queries (time series, period totals, category breakdown, averages)
 │   │   ├── queries/work-expenses.ts      # Work expense queries (period totals, time series, category breakdown)
@@ -394,7 +395,7 @@ finance-stack/
 │   │       ├── vitest-setup.ts           #   Per-test setup/teardown
 │   │       ├── actions/                  #   Server action tests (account, transaction)
 │   │       ├── api/                      #   API route tests (health drift check)
-│   │       └── queries/                  #   Query function tests (rebuild-balance, liabilities-drilldown)
+│   │       └── queries/                  #   Query function tests (accounting, rebuild-balance, drilldowns)
 │   └── vitest.config.ts                  # Vitest configuration (unit + integration projects)
 ├── importer/                              # File import service
 │   ├── poll.py                            # Polling loop and parser dispatcher (committed)
@@ -454,6 +455,11 @@ Data is persisted in Docker volumes and will be available on next startup.
 ## Updates
 
 ### 2026-06-07 — v0.1.3.1 (in progress)
+
+**Extract `amountColorClass` + shared SQL aggregations ([Issue #134](https://github.com/aellington89/finance-stack/issues/134))**
+- `amountColorClass()` — a pure Tailwind text-color helper — lived inside the [`accounts-table.tsx`](app/components/accounts/accounts-table.tsx) component and was re-imported from there into [`transaction-list.tsx`](app/components/transactions/transaction-list.tsx). It was also byte-for-byte identical to `changeColor()` already in [`app/lib/format/financial.ts`](app/lib/format/financial.ts) (same green/red/empty logic), so the codebase carried two names for one behavior. Consolidated to a single `amountColorClass` in `financial.ts`; deleted `changeColor` and repointed its call sites in [`liabilities/page.tsx`](app/app/(app)/dashboard/liabilities/page.tsx), [`asset-performance-table.tsx`](app/components/dashboard/asset-performance-table.tsx), and [`liability-performance-table.tsx`](app/components/dashboard/liability-performance-table.tsx). Pure rename/move — the function body is unchanged, so every call site emits the same classes and there is no UI change.
+- Two `SUM(CASE WHEN …)` SQL blocks were copy-pasted across the query layer, risking divergent null/rounding handling: a *sum-by-transaction-type* block (`SUM(CASE WHEN t.transaction_type_id = X THEN ABS(t.amount) ELSE 0 END)`) in [`accounting.ts`](app/lib/queries/accounting.ts) and [`work-expenses.ts`](app/lib/queries/work-expenses.ts), and a *balance-snapshot-at-date* block (`COALESCE(SUM(CASE WHEN abh.balance_date = X THEN abh.cumulative_balance ELSE 0 END), 0)`) in [`net-worth-drilldown.ts`](app/lib/queries/net-worth-drilldown.ts), [`assets-drilldown.ts`](app/lib/queries/assets-drilldown.ts), and [`liabilities-drilldown.ts`](app/lib/queries/liabilities-drilldown.ts). Both now come from `sumAmountByType()` / `balanceAtDate()` in the new [`app/lib/queries/_aggregates.ts`](app/lib/queries/_aggregates.ts) — establishing the `_`-prefixed shared-helper convention for the queries layer. Mechanical extraction only: the generated SQL (and thus query output) is unchanged.
+- New unit tests: [`tests/unit/lib/queries/_aggregates.test.ts`](app/tests/unit/lib/queries/_aggregates.test.ts) renders each fragment via Drizzle's `PgDialect` and asserts the exact parameterized SQL (with/without a predicate; string date vs `CURRENT_DATE`), and the `changeColor` block in [`tests/unit/lib/format/financial.test.ts`](app/tests/unit/lib/format/financial.test.ts) was renamed to `amountColorClass` (same behavior contract). The existing drilldown integration suites guard that the Pattern B query output is unchanged; a new [`tests/integration/queries/accounting.test.ts`](app/tests/integration/queries/accounting.test.ts) closes the prior coverage gap on the Pattern A files — it seeds a dedicated account with controlled transactions and asserts exact period totals, monthly buckets, to-date comparison, expense-category breakdown, and trailing-12-month averages (incl. the empty-range → zero path).
 
 **Centralize date-range validation ([Issue #150](https://github.com/aellington89/finance-stack/issues/150))**
 - `dateFrom`/`dateTo` URL params were handled inconsistently across three layers: [`getDateRangeFromParams()`](app/lib/queries/date-range.ts) **silently swapped** an out-of-order range and did no format check; [`accounting.ts`](app/lib/queries/accounting.ts) and [`work-expenses.ts`](app/lib/queries/work-expenses.ts) each carried a private `safeDate`/`DATE_RE` that silently dropped bad dates; and the dashboard/assets/net-worth queries fed params straight into a SQL `::date` cast, so a malformed value (e.g. `?dateFrom=banana`) surfaced as a raw Postgres 500 → generic "Something went wrong". The net effect was wrong-but-silent results or opaque errors.

--- a/app/app/(app)/dashboard/liabilities/page.tsx
+++ b/app/app/(app)/dashboard/liabilities/page.tsx
@@ -23,7 +23,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { changeColor, signedCurrency } from "@/lib/format/financial";
+import { amountColorClass, signedCurrency } from "@/lib/format/financial";
 
 export const dynamic = "force-dynamic";
 
@@ -111,7 +111,7 @@ export default async function LiabilitiesDrilldownPage({
           </CardHeader>
           <CardContent>
             <span
-              className={`text-5xl font-bold tabular-nums tracking-tight ${changeColor(performance.totalChange)}`}
+              className={`text-5xl font-bold tabular-nums tracking-tight ${amountColorClass(performance.totalChange)}`}
             >
               {signedCurrency(performance.totalChange)}
             </span>

--- a/app/components/accounts/accounts-table.tsx
+++ b/app/components/accounts/accounts-table.tsx
@@ -22,6 +22,7 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
+import { amountColorClass } from "@/lib/format/financial";
 import type { AccountBalanceRow } from "@/lib/queries/accounts";
 
 interface AccountEntry {
@@ -396,17 +397,4 @@ function AccountTypeRows({
         ))}
     </>
   );
-}
-
-/**
- * Unified color logic for account dollar amounts:
- * - Positive: green (asset growth or liability paydown)
- * - Zero: white/default
- * - Negative: red (asset loss or increasing debt)
- */
-export function amountColorClass(value: number): string {
-  if (value === 0) return "";
-  return value > 0
-    ? "text-green-600 dark:text-green-400"
-    : "text-red-600 dark:text-red-400";
 }

--- a/app/components/dashboard/asset-performance-table.tsx
+++ b/app/components/dashboard/asset-performance-table.tsx
@@ -6,7 +6,7 @@ import type { PerformanceData } from "@/lib/queries/assets-drilldown";
 import {
   signedCurrency,
   signedPercent,
-  changeColor,
+  amountColorClass,
 } from "@/lib/format/financial";
 import {
   Table,
@@ -112,12 +112,12 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                       {formatCurrency(cat.currentValue)}
                     </TableCell>
                     <TableCell
-                      className={`text-right tabular-nums ${changeColor(cat.change)}`}
+                      className={`text-right tabular-nums ${amountColorClass(cat.change)}`}
                     >
                       {signedCurrency(cat.change)}
                     </TableCell>
                     <TableCell
-                      className={`text-right tabular-nums ${changeColor(cat.percentChange)}`}
+                      className={`text-right tabular-nums ${amountColorClass(cat.percentChange)}`}
                     >
                       {signedPercent(cat.percentChange)}
                     </TableCell>
@@ -150,12 +150,12 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                               {formatCurrency(type.currentValue)}
                             </TableCell>
                             <TableCell
-                              className={`text-right tabular-nums ${changeColor(type.change)}`}
+                              className={`text-right tabular-nums ${amountColorClass(type.change)}`}
                             >
                               {signedCurrency(type.change)}
                             </TableCell>
                             <TableCell
-                              className={`text-right tabular-nums ${changeColor(type.percentChange)}`}
+                              className={`text-right tabular-nums ${amountColorClass(type.percentChange)}`}
                             >
                               {signedPercent(type.percentChange)}
                             </TableCell>
@@ -176,12 +176,12 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                                   {formatCurrency(acc.currentValue)}
                                 </TableCell>
                                 <TableCell
-                                  className={`text-right tabular-nums ${changeColor(acc.change)}`}
+                                  className={`text-right tabular-nums ${amountColorClass(acc.change)}`}
                                 >
                                   {signedCurrency(acc.change)}
                                 </TableCell>
                                 <TableCell
-                                  className={`text-right tabular-nums ${changeColor(acc.percentChange)}`}
+                                  className={`text-right tabular-nums ${amountColorClass(acc.percentChange)}`}
                                 >
                                   {signedPercent(acc.percentChange)}
                                 </TableCell>
@@ -204,12 +204,12 @@ export function AssetPerformanceTable({ data }: AssetPerformanceTableProps) {
                 {formatCurrency(data.totalCurrentValue)}
               </TableCell>
               <TableCell
-                className={`text-right font-bold tabular-nums ${changeColor(data.totalChange)}`}
+                className={`text-right font-bold tabular-nums ${amountColorClass(data.totalChange)}`}
               >
                 {signedCurrency(data.totalChange)}
               </TableCell>
               <TableCell
-                className={`text-right font-bold tabular-nums ${changeColor(data.totalPercentChange)}`}
+                className={`text-right font-bold tabular-nums ${amountColorClass(data.totalPercentChange)}`}
               >
                 {signedPercent(data.totalPercentChange)}
               </TableCell>

--- a/app/components/dashboard/liability-performance-table.tsx
+++ b/app/components/dashboard/liability-performance-table.tsx
@@ -6,7 +6,7 @@ import type { LiabilityPerformanceData } from "@/lib/queries/liabilities-drilldo
 import {
   signedCurrency,
   signedPercent,
-  changeColor,
+  amountColorClass,
 } from "@/lib/format/financial";
 import {
   Table,
@@ -125,14 +125,14 @@ export function LiabilityPerformanceTable({
                       {formatCurrency(cat.currentValue)}
                     </TableCell>
                     <TableCell
-                      className={`text-right tabular-nums ${changeColor(cat.change)}`}
+                      className={`text-right tabular-nums ${amountColorClass(cat.change)}`}
                     >
                       {signedCurrency(cat.change)}
                     </TableCell>
                     <TableCell
                       className={`text-right tabular-nums ${
                         cat.percentChange !== null
-                          ? changeColor(cat.percentChange)
+                          ? amountColorClass(cat.percentChange)
                           : ""
                       }`}
                     >
@@ -167,14 +167,14 @@ export function LiabilityPerformanceTable({
                               {formatCurrency(type.currentValue)}
                             </TableCell>
                             <TableCell
-                              className={`text-right tabular-nums ${changeColor(type.change)}`}
+                              className={`text-right tabular-nums ${amountColorClass(type.change)}`}
                             >
                               {signedCurrency(type.change)}
                             </TableCell>
                             <TableCell
                               className={`text-right tabular-nums ${
                                 type.percentChange !== null
-                                  ? changeColor(type.percentChange)
+                                  ? amountColorClass(type.percentChange)
                                   : ""
                               }`}
                             >
@@ -197,14 +197,14 @@ export function LiabilityPerformanceTable({
                                   {formatCurrency(acc.currentValue)}
                                 </TableCell>
                                 <TableCell
-                                  className={`text-right tabular-nums ${changeColor(acc.change)}`}
+                                  className={`text-right tabular-nums ${amountColorClass(acc.change)}`}
                                 >
                                   {signedCurrency(acc.change)}
                                 </TableCell>
                                 <TableCell
                                   className={`text-right tabular-nums ${
                                     acc.percentChange !== null
-                                      ? changeColor(acc.percentChange)
+                                      ? amountColorClass(acc.percentChange)
                                       : ""
                                   }`}
                                 >
@@ -229,14 +229,14 @@ export function LiabilityPerformanceTable({
                 {formatCurrency(data.totalCurrentValue)}
               </TableCell>
               <TableCell
-                className={`text-right font-bold tabular-nums ${changeColor(data.totalChange)}`}
+                className={`text-right font-bold tabular-nums ${amountColorClass(data.totalChange)}`}
               >
                 {signedCurrency(data.totalChange)}
               </TableCell>
               <TableCell
                 className={`text-right font-bold tabular-nums ${
                   data.totalPercentChange !== null
-                    ? changeColor(data.totalPercentChange)
+                    ? amountColorClass(data.totalPercentChange)
                     : ""
                 }`}
               >

--- a/app/components/transactions/transaction-list.tsx
+++ b/app/components/transactions/transaction-list.tsx
@@ -25,7 +25,7 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
-import { amountColorClass } from "@/components/accounts/accounts-table";
+import { amountColorClass } from "@/lib/format/financial";
 import type { SortableColumn, SortDirection } from "@/lib/queries/transactions";
 import { TransactionEditRow } from "@/components/transactions/transaction-edit-row";
 import { TransactionDeleteDialog } from "@/components/transactions/transaction-delete-dialog";

--- a/app/lib/format/financial.ts
+++ b/app/lib/format/financial.ts
@@ -20,7 +20,11 @@ export function signedPercent(n: number): string {
   return `${abs}%`;
 }
 
-export function changeColor(n: number): string {
+/**
+ * Tailwind text-color class for a signed monetary value — amounts, balances,
+ * and period changes. Green for positive, red for negative, none for zero.
+ */
+export function amountColorClass(n: number): string {
   if (n > 0) return "text-green-600 dark:text-green-400";
   if (n < 0) return "text-red-600 dark:text-red-400";
   return "";

--- a/app/lib/queries/_aggregates.ts
+++ b/app/lib/queries/_aggregates.ts
@@ -1,0 +1,48 @@
+import { sql, type SQL } from "drizzle-orm";
+
+/**
+ * Shared SQL aggregation fragments for the query layer.
+ *
+ * These return Drizzle `SQL` fragments (a single `SELECT` column each) so the
+ * repeated `SUM(CASE WHEN …)` blocks live in one place and their null/rounding
+ * handling stays consistent. They do NOT touch the database.
+ *
+ * Aliases are injected via `sql.raw` — they are static, internal identifiers,
+ * never user input.
+ */
+
+/**
+ * Pattern A — sum a transaction amount for a single transaction type:
+ *
+ *   SUM(CASE WHEN t.transaction_type_id = <typeId> [AND <predicate>]
+ *            THEN ABS(t.amount) ELSE 0 END) AS <alias>
+ *
+ * The optional `predicate` adds extra CASE conditions (e.g. the date-window
+ * arms of the to-date comparison query).
+ *
+ * Assumes the `transactions` table is aliased `t` in the surrounding query.
+ */
+export function sumAmountByType(
+  typeId: number,
+  alias: string,
+  predicate?: SQL
+): SQL {
+  const guard = predicate ? sql` AND ${predicate}` : sql``;
+  return sql`SUM(CASE WHEN t.transaction_type_id = ${typeId}${guard} THEN ABS(t.amount) ELSE 0 END) AS ${sql.raw(alias)}`;
+}
+
+/**
+ * Pattern B — cumulative account balance snapshot on a specific date:
+ *
+ *   COALESCE(SUM(CASE WHEN abh.balance_date = <date>::date
+ *            THEN abh.cumulative_balance ELSE 0 END), 0) AS <alias>
+ *
+ * `date` is `string | SQL`: a `YYYY-MM-DD` string, or a SQL expression such as
+ * sql`CURRENT_DATE` (used when the caller's `dateTo` is omitted).
+ *
+ * Assumes the `account_balance_history` table is aliased `abh` in the
+ * surrounding query.
+ */
+export function balanceAtDate(date: string | SQL, alias: string): SQL {
+  return sql`COALESCE(SUM(CASE WHEN abh.balance_date = ${date}::date THEN abh.cumulative_balance ELSE 0 END), 0) AS ${sql.raw(alias)}`;
+}

--- a/app/lib/queries/accounting.ts
+++ b/app/lib/queries/accounting.ts
@@ -6,6 +6,7 @@ import {
   INVESTMENT_TYPE,
 } from "@/lib/constants/reference-ids";
 import { isValidIsoDate } from "@/lib/validations/date-range";
+import { sumAmountByType } from "@/lib/queries/_aggregates";
 
 // ── Types ──
 
@@ -170,9 +171,9 @@ export async function getAccountingTimeSeries(
       agg AS (
         SELECT
           ${sql.raw(groupExpr)} AS date,
-          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_income,
-          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+          ${sumAmountByType(INCOME_TYPE.id, "total_income")},
+          ${sumAmountByType(EXPENSE_TYPE.id, "total_expenses")},
+          ${sumAmountByType(INVESTMENT_TYPE.id, "total_investments")}
         FROM transactions t
         ${where}
         GROUP BY 1
@@ -206,9 +207,9 @@ export async function getAccountingTimeSeries(
       agg AS (
         SELECT
           ${sql.raw(groupExpr)} AS date,
-          SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_income,
-          SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-          SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+          ${sumAmountByType(INCOME_TYPE.id, "total_income")},
+          ${sumAmountByType(EXPENSE_TYPE.id, "total_expenses")},
+          ${sumAmountByType(INVESTMENT_TYPE.id, "total_investments")}
         FROM transactions t
         ${where}
         GROUP BY 1
@@ -248,9 +249,9 @@ export async function getAccountingPeriodTotals(
 
   const result = await db.execute(sql`
     SELECT
-      SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_income,
-      SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-      SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_investments
+      ${sumAmountByType(INCOME_TYPE.id, "total_income")},
+      ${sumAmountByType(EXPENSE_TYPE.id, "total_expenses")},
+      ${sumAmountByType(INVESTMENT_TYPE.id, "total_investments")}
     FROM transactions t
     ${where}
   `);
@@ -335,6 +336,9 @@ export async function getAccountingToDateComparison(
     ? sql`AND ${sql.join(extraConditions, sql` AND `)}`
     : sql``;
 
+  const curWindow = sql`t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end`;
+  const prevWindow = sql`t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end`;
+
   const result = await db.execute(sql`
     WITH params AS (
       SELECT
@@ -344,12 +348,12 @@ export async function getAccountingToDateComparison(
         (date_trunc(${sql.raw(`'${truncation}'`)}, ${refDate}::date) - interval '1 day')::date AS prev_end
     )
     SELECT
-      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS cur_income,
-      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS prev_income,
-      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS cur_expenses,
-      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS prev_expenses,
-      SUM(CASE WHEN t.transaction_date >= p.cur_start AND t.transaction_date <= p.cur_end AND t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS cur_investments,
-      SUM(CASE WHEN t.transaction_date >= p.prev_start AND t.transaction_date <= p.prev_end AND t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS prev_investments,
+      ${sumAmountByType(INCOME_TYPE.id, "cur_income", curWindow)},
+      ${sumAmountByType(INCOME_TYPE.id, "prev_income", prevWindow)},
+      ${sumAmountByType(EXPENSE_TYPE.id, "cur_expenses", curWindow)},
+      ${sumAmountByType(EXPENSE_TYPE.id, "prev_expenses", prevWindow)},
+      ${sumAmountByType(INVESTMENT_TYPE.id, "cur_investments", curWindow)},
+      ${sumAmountByType(INVESTMENT_TYPE.id, "prev_investments", prevWindow)},
       MIN(${sql.raw(curLabelExpr)}) AS cur_label,
       MIN(${sql.raw(prevLabelExpr)}) AS prev_label
     FROM transactions t
@@ -427,9 +431,9 @@ export async function getAccountingMonthlyAverages(
     WITH monthly AS (
       SELECT
         date_trunc('month', t.transaction_date) AS month,
-        SUM(CASE WHEN t.transaction_type_id = ${INCOME_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS income,
-        SUM(CASE WHEN t.transaction_type_id = ${EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS expenses,
-        SUM(CASE WHEN t.transaction_type_id = ${INVESTMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS investments
+        ${sumAmountByType(INCOME_TYPE.id, "income")},
+        ${sumAmountByType(EXPENSE_TYPE.id, "expenses")},
+        ${sumAmountByType(INVESTMENT_TYPE.id, "investments")}
       FROM transactions t
       WHERE t.transaction_date >= date_trunc('month', CURRENT_DATE) - interval '12 months'
         AND t.transaction_date < date_trunc('month', CURRENT_DATE)

--- a/app/lib/queries/assets-drilldown.ts
+++ b/app/lib/queries/assets-drilldown.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
+import { balanceAtDate } from "@/lib/queries/_aggregates";
 
 // Asset categories: Current Asset (1), Restricted Asset (2), Fixed Asset (3),
 // Investment (4). Liabilities (5, 6) are excluded. Restricted is kept in the
@@ -258,10 +259,8 @@ export async function getAssetPerformance(
       at.account_type AS account_type_name,
       a.account_id,
       a.account_name,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+      ${balanceAtDate(dateFrom, "start_balance")},
+      ${balanceAtDate(endDate, "end_balance")}
     FROM account_balance_history abh
     JOIN accounts a ON a.account_id = abh.account_id
     JOIN account_types at ON at.account_type_id = a.account_type_id

--- a/app/lib/queries/liabilities-drilldown.ts
+++ b/app/lib/queries/liabilities-drilldown.ts
@@ -7,6 +7,7 @@ import {
   LIABILITY_CURRENT_CATEGORY_ID,
   LIABILITY_NON_CURRENT_CATEGORY_ID,
 } from "@/lib/queries/liability-categories";
+import { balanceAtDate } from "@/lib/queries/_aggregates";
 
 // Sign convention: liability balances are stored as negative numbers in
 // account_balance_history. We preserve that sign throughout — this module
@@ -309,10 +310,8 @@ export async function getLiabilityPerformance(
       at.account_type AS account_type_name,
       a.account_id,
       a.account_name,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+      ${balanceAtDate(dateFrom, "start_balance")},
+      ${balanceAtDate(endDate, "end_balance")}
     FROM account_balance_history abh
     JOIN accounts a ON a.account_id = abh.account_id
     JOIN account_types at ON at.account_type_id = a.account_type_id
@@ -702,10 +701,8 @@ export async function getDebtWaterfall(
 
   const balanceResult = await db.execute(sql`
     SELECT
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+      ${balanceAtDate(dateFrom, "start_balance")},
+      ${balanceAtDate(endDate, "end_balance")}
     FROM account_balance_history abh
     JOIN accounts a ON a.account_id = abh.account_id
     JOIN account_types at ON at.account_type_id = a.account_type_id

--- a/app/lib/queries/net-worth-drilldown.ts
+++ b/app/lib/queries/net-worth-drilldown.ts
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
 import { RESTRICTED_ASSET_CATEGORY } from "@/lib/constants/reference-ids";
+import { balanceAtDate } from "@/lib/queries/_aggregates";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -76,10 +77,8 @@ export async function getNetWorthWaterfall(
     SELECT
       atc.account_type_category_id AS category_id,
       atc.account_type_category AS category_name,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+      ${balanceAtDate(dateFrom, "start_balance")},
+      ${balanceAtDate(endDate, "end_balance")}
     FROM account_balance_history abh
     JOIN accounts a ON a.account_id = abh.account_id
     JOIN account_types at ON at.account_type_id = a.account_type_id
@@ -137,10 +136,8 @@ export async function getNetWorthDrivers(
       at.account_type AS account_type_name,
       a.account_id,
       a.account_name,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${dateFrom}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance,
-      COALESCE(SUM(CASE WHEN abh.balance_date = ${endDate}::date
-        THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance
+      ${balanceAtDate(dateFrom, "start_balance")},
+      ${balanceAtDate(endDate, "end_balance")}
     FROM account_balance_history abh
     JOIN accounts a ON a.account_id = abh.account_id
     JOIN account_types at ON at.account_type_id = a.account_type_id

--- a/app/lib/queries/work-expenses.ts
+++ b/app/lib/queries/work-expenses.ts
@@ -6,6 +6,7 @@ import {
   WORK_EXPENSE_REIMBURSEMENT_TYPE,
 } from "@/lib/constants/reference-ids";
 import { isValidIsoDate } from "@/lib/validations/date-range";
+import { sumAmountByType } from "@/lib/queries/_aggregates";
 
 // ── Types ──
 
@@ -70,8 +71,8 @@ export async function getWorkExpenseTotals(
 
   const result = await db.execute(sql`
     SELECT
-      SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_work_expenses,
-      SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_REIMBURSEMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_reimbursements
+      ${sumAmountByType(WORK_EXPENSE_TYPE.id, "total_work_expenses")},
+      ${sumAmountByType(WORK_EXPENSE_REIMBURSEMENT_TYPE.id, "total_reimbursements")}
     FROM transactions t
     ${where}
   `);
@@ -103,8 +104,8 @@ export async function getWorkExpenseTimeSeries(
     agg AS (
       SELECT
         date_trunc('month', t.transaction_date)::date AS date,
-        SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_expenses,
-        SUM(CASE WHEN t.transaction_type_id = ${WORK_EXPENSE_REIMBURSEMENT_TYPE.id} THEN ABS(t.amount) ELSE 0 END) AS total_reimbursements
+        ${sumAmountByType(WORK_EXPENSE_TYPE.id, "total_expenses")},
+        ${sumAmountByType(WORK_EXPENSE_REIMBURSEMENT_TYPE.id, "total_reimbursements")}
       FROM transactions t
       WHERE t.transaction_date >= date_trunc('month', ${dateFrom}::date)::date
         AND t.transaction_date <= ${dateTo}::date

--- a/app/tests/integration/queries/accounting.test.ts
+++ b/app/tests/integration/queries/accounting.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { db } from "@/lib/db";
+import { accounts, transactions } from "@/drizzle/schema";
+import { inArray } from "drizzle-orm";
+import {
+  getAccountingTimeSeries,
+  getAccountingPeriodTotals,
+  getAccountingToDateComparison,
+  getExpenseCategoryBreakdown,
+  getAccountingMonthlyAverages,
+} from "@/lib/queries/accounting";
+import {
+  INCOME_TYPE,
+  EXPENSE_TYPE,
+  INVESTMENT_TYPE,
+} from "@/lib/constants/reference-ids";
+
+// All transactions are scoped to a freshly created account and filtered by
+// `accountIds`, so these tests never see seed data and assert exact totals.
+//
+// The dated queries use a 2020 window (outside the mock-data seed range); the
+// monthly-averages query has its own fixed "last 12 complete months" window, so
+// it gets a separate row in a recent complete month (~3 months ago).
+
+const TYPE_CASH = 1; // account_types row guaranteed by vitest-setup.ts
+
+// Categories guaranteed by vitest-setup.ts upserts.
+const CAT_OTHER = 6; // "Other"
+const CAT_CC_INTEREST = 80; // "Credit Card Interest"
+
+// A day in a complete month inside the trailing-12-month averages window.
+const RECENT = new Date(
+  Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() - 3, 15)
+)
+  .toISOString()
+  .slice(0, 10);
+
+const createdAccountIds: number[] = [];
+
+async function createAccount(name: string): Promise<number> {
+  const [row] = await db
+    .insert(accounts)
+    .values({ accountName: name, accountTypeId: TYPE_CASH })
+    .returning({ accountId: accounts.accountId });
+  createdAccountIds.push(row.accountId);
+  return row.accountId;
+}
+
+async function insertTxn(
+  accountId: number,
+  date: string,
+  amount: string,
+  transactionTypeId: number,
+  transactionCategoryId: number,
+  description = "test txn"
+) {
+  await db.insert(transactions).values({
+    transactionDescription: description,
+    transactionDate: date,
+    accountId,
+    amount,
+    transactionTypeId,
+    transactionCategoryId,
+  });
+}
+
+let accountId: number;
+
+beforeEach(async () => {
+  accountId = await createAccount("Accounting Test Acct");
+
+  // ── 2020 window (dated queries) ──
+  // Jan 2020
+  await insertTxn(accountId, "2020-01-10", "300.00", INCOME_TYPE.id, CAT_OTHER);
+  await insertTxn(accountId, "2020-01-15", "-50.00", EXPENSE_TYPE.id, CAT_OTHER);
+  // Feb 2020
+  await insertTxn(accountId, "2020-02-05", "1000.00", INCOME_TYPE.id, CAT_OTHER);
+  await insertTxn(accountId, "2020-02-12", "500.00", INCOME_TYPE.id, CAT_OTHER);
+  await insertTxn(accountId, "2020-02-18", "-400.00", EXPENSE_TYPE.id, CAT_OTHER);
+  await insertTxn(accountId, "2020-02-20", "-100.00", EXPENSE_TYPE.id, CAT_CC_INTEREST);
+  await insertTxn(accountId, "2020-02-25", "-200.00", INVESTMENT_TYPE.id, CAT_OTHER);
+
+  // ── Recent complete month (monthly-averages window) ──
+  await insertTxn(accountId, RECENT, "1200.00", INCOME_TYPE.id, CAT_OTHER);
+  await insertTxn(accountId, RECENT, "-600.00", EXPENSE_TYPE.id, CAT_OTHER);
+  await insertTxn(accountId, RECENT, "-300.00", INVESTMENT_TYPE.id, CAT_OTHER);
+});
+
+afterEach(async () => {
+  if (createdAccountIds.length > 0) {
+    await db
+      .delete(transactions)
+      .where(inArray(transactions.accountId, createdAccountIds));
+    await db.delete(accounts).where(inArray(accounts.accountId, createdAccountIds));
+    createdAccountIds.length = 0;
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getAccountingPeriodTotals
+// ────────────────────────────────────────────────────────────────────
+
+describe("getAccountingPeriodTotals", () => {
+  it("sums income/expense/investment (via ABS) over the date range", async () => {
+    const result = await getAccountingPeriodTotals({
+      dateFrom: "2020-01-01",
+      dateTo: "2020-02-29",
+      accountIds: [accountId],
+    });
+
+    expect(result.totalIncome).toBeCloseTo(1800, 2); // 300 + 1000 + 500
+    expect(result.totalExpenses).toBeCloseTo(550, 2); // |−50| + |−400| + |−100|
+    expect(result.totalInvestments).toBeCloseTo(200, 2); // |−200|
+  });
+
+  it("returns zeros (not null) when nothing matches the range", async () => {
+    const result = await getAccountingPeriodTotals({
+      dateFrom: "2019-01-01",
+      dateTo: "2019-12-31",
+      accountIds: [accountId],
+    });
+
+    expect(result.totalIncome).toBe(0);
+    expect(result.totalExpenses).toBe(0);
+    expect(result.totalInvestments).toBe(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getAccountingTimeSeries
+// ────────────────────────────────────────────────────────────────────
+
+describe("getAccountingTimeSeries", () => {
+  it("buckets totals by month across the range", async () => {
+    const result = await getAccountingTimeSeries({
+      dateFrom: "2020-01-01",
+      dateTo: "2020-02-29",
+      accountIds: [accountId],
+      timeGrouping: "month",
+    });
+
+    const jan = result.find((p) => p.date.startsWith("2020-01"));
+    const feb = result.find((p) => p.date.startsWith("2020-02"));
+
+    expect(jan).toBeDefined();
+    expect(jan!.totalIncome).toBeCloseTo(300, 2);
+    expect(jan!.totalExpenses).toBeCloseTo(50, 2);
+    expect(jan!.totalInvestments).toBeCloseTo(0, 2);
+
+    expect(feb).toBeDefined();
+    expect(feb!.totalIncome).toBeCloseTo(1500, 2);
+    expect(feb!.totalExpenses).toBeCloseTo(500, 2);
+    expect(feb!.totalInvestments).toBeCloseTo(200, 2);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getAccountingToDateComparison
+// ────────────────────────────────────────────────────────────────────
+
+describe("getAccountingToDateComparison", () => {
+  it("compares the current month-to-date against the prior month", async () => {
+    const result = await getAccountingToDateComparison({
+      dateTo: "2020-02-29", // reference date → current = Feb, previous = Jan
+      accountIds: [accountId],
+      timeGrouping: "month",
+    });
+
+    expect(result.currentIncome).toBeCloseTo(1500, 2);
+    expect(result.previousIncome).toBeCloseTo(300, 2);
+    expect(result.currentExpenses).toBeCloseTo(500, 2);
+    expect(result.previousExpenses).toBeCloseTo(50, 2);
+    expect(result.currentInvestments).toBeCloseTo(200, 2);
+    expect(result.previousInvestments).toBeCloseTo(0, 2);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getExpenseCategoryBreakdown
+// ────────────────────────────────────────────────────────────────────
+
+describe("getExpenseCategoryBreakdown", () => {
+  it("groups expenses by category, ordered by total descending", async () => {
+    const result = await getExpenseCategoryBreakdown({
+      dateFrom: "2020-01-01",
+      dateTo: "2020-02-29",
+      accountIds: [accountId],
+    });
+
+    const other = result.find((r) => r.category === "Other");
+    const ccInterest = result.find((r) => r.category === "Credit Card Interest");
+
+    expect(other?.total).toBeCloseTo(450, 2); // |−50| + |−400|
+    expect(ccInterest?.total).toBeCloseTo(100, 2); // |−100|
+
+    // Ordered by total DESC: "Other" (450) precedes "Credit Card Interest" (100).
+    const otherIdx = result.findIndex((r) => r.category === "Other");
+    const ccIdx = result.findIndex((r) => r.category === "Credit Card Interest");
+    expect(otherIdx).toBeLessThan(ccIdx);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// getAccountingMonthlyAverages
+// ────────────────────────────────────────────────────────────────────
+
+describe("getAccountingMonthlyAverages", () => {
+  it("averages over complete months in the trailing-12-month window", async () => {
+    // Only the single recent month has rows for this account, so the averages
+    // equal that month's totals. (The 2020 rows fall outside the window.)
+    const result = await getAccountingMonthlyAverages({
+      accountIds: [accountId],
+    });
+
+    expect(result.totalIncome).toBeCloseTo(1200, 2);
+    expect(result.totalExpenses).toBeCloseTo(600, 2);
+    expect(result.totalInvestments).toBeCloseTo(300, 2);
+  });
+});

--- a/app/tests/unit/lib/format/financial.test.ts
+++ b/app/tests/unit/lib/format/financial.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   signedCurrency,
   signedPercent,
-  changeColor,
+  amountColorClass,
 } from "@/lib/format/financial";
 
 describe("signedCurrency", () => {
@@ -38,16 +38,16 @@ describe("signedPercent", () => {
   });
 });
 
-describe("changeColor", () => {
+describe("amountColorClass", () => {
   it("returns green for positive values", () => {
-    expect(changeColor(1)).toContain("green");
+    expect(amountColorClass(1)).toContain("green");
   });
 
   it("returns red for negative values", () => {
-    expect(changeColor(-1)).toContain("red");
+    expect(amountColorClass(-1)).toContain("red");
   });
 
   it("returns an empty class for zero", () => {
-    expect(changeColor(0)).toBe("");
+    expect(amountColorClass(0)).toBe("");
   });
 });

--- a/app/tests/unit/lib/queries/_aggregates.test.ts
+++ b/app/tests/unit/lib/queries/_aggregates.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { sumAmountByType, balanceAtDate } from "@/lib/queries/_aggregates";
+
+// Render a SQL fragment to its parameterized text + params so we can assert the
+// exact generated SQL and guard against accidental drift.
+const dialect = new PgDialect();
+const render = (frag: ReturnType<typeof sumAmountByType>) =>
+  dialect.sqlToQuery(frag);
+
+describe("sumAmountByType", () => {
+  it("builds a typed SUM(CASE) column without a predicate", () => {
+    const { sql: text, params } = render(sumAmountByType(4, "total_income"));
+    expect(text).toBe(
+      "SUM(CASE WHEN t.transaction_type_id = $1 THEN ABS(t.amount) ELSE 0 END) AS total_income"
+    );
+    expect(params).toEqual([4]);
+  });
+
+  it("ANDs an extra predicate into the CASE arm", () => {
+    const { sql: text, params } = render(
+      sumAmountByType(2, "cur_expenses", sql`t.transaction_date >= p.cur_start`)
+    );
+    expect(text).toBe(
+      "SUM(CASE WHEN t.transaction_type_id = $1 AND t.transaction_date >= p.cur_start THEN ABS(t.amount) ELSE 0 END) AS cur_expenses"
+    );
+    expect(params).toEqual([2]);
+  });
+});
+
+describe("balanceAtDate", () => {
+  it("builds a COALESCE'd balance snapshot for a string date", () => {
+    const { sql: text, params } = render(
+      balanceAtDate("2024-01-01", "start_balance")
+    );
+    expect(text).toBe(
+      "COALESCE(SUM(CASE WHEN abh.balance_date = $1::date THEN abh.cumulative_balance ELSE 0 END), 0) AS start_balance"
+    );
+    expect(params).toEqual(["2024-01-01"]);
+  });
+
+  it("inlines a SQL date expression like CURRENT_DATE", () => {
+    const { sql: text, params } = render(
+      balanceAtDate(sql`CURRENT_DATE`, "end_balance")
+    );
+    expect(text).toBe(
+      "COALESCE(SUM(CASE WHEN abh.balance_date = CURRENT_DATE::date THEN abh.cumulative_balance ELSE 0 END), 0) AS end_balance"
+    );
+    expect(params).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #134.

Mechanical tech-debt extraction — **no UI change and no query-output change**.

## Color helper (one function)
`changeColor` and `amountColorClass` were byte-for-byte identical, so the codebase carried two names for one behavior. Consolidated to a single `amountColorClass` in `app/lib/format/financial.ts`, deleted `changeColor`, and repointed every call site (`accounts-table`, `transaction-list`, `liabilities` page, asset- and liability-performance tables). The function body is unchanged, so every call site emits the same classes.

## Shared SQL aggregations
New `app/lib/queries/_aggregates.ts` centralizes two copy-pasted `SUM(CASE WHEN …)` patterns (establishing the `_`-prefixed shared-helper convention):
- `sumAmountByType(typeId, alias, predicate?)` — **Pattern A** (sum amount by transaction type) → `accounting.ts` (incl. the to-date comparison's date-window predicate) + `work-expenses.ts`.
- `balanceAtDate(date, alias)` — **Pattern B** (cumulative balance snapshot at a date) → `net-worth-drilldown.ts`, `assets-drilldown.ts`, `liabilities-drilldown.ts`.

> Note: the issue framed this as one income/expense block shared by three files, but the income/expense pattern is confined to `accounting.ts` while the cross-file pattern is the balance snapshot. Both patterns are addressed, extended to `work-expenses.ts` and `liabilities-drilldown.ts` for full consistency.

## Tests & docs
- `tests/unit/lib/queries/_aggregates.test.ts` — renders each fragment via Drizzle's `PgDialect` and asserts the **exact** generated SQL (with/without predicate; string date vs `CURRENT_DATE`).
- `tests/unit/lib/format/financial.test.ts` — `changeColor` block renamed to `amountColorClass` (same behavior contract).
- `tests/integration/queries/accounting.test.ts` — **new**, closes the prior Pattern A coverage gap (period totals, monthly buckets, to-date comparison, expense-category breakdown, trailing-12-month averages, empty-range → zero path).
- README `## Updates` changelog (#134) + `## Project Structure` updated.

## Verification
- `tsc --noEmit` clean · `eslint` clean
- Full suite: **240 passed** (26 files) — unit + integration, incl. all drilldown suites and the new accounting suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)