### PR TITLE
Issue #147 - Enforce non-blank transaction_description and account_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Database `CHECK` constraints (`transactions_transaction_description_not_blank`, `accounts_account_name_not_blank`) rejecting empty-string `transaction_description` / `account_name` — closing the gap where `NOT NULL` still permitted `''` that the app's `min(1)` validators reject. The `0002` migration backfills any pre-existing empty rows to a sentinel before enforcing the constraint. The columns and their FKs were already `NOT NULL`/constrained, so this empty-string tightening is the substantive change ([Issue #147](https://github.com/aellington89/finance-stack/issues/147)).
+
 ## [0.1.4] - 2026-07-05
 
 ### Added

--- a/app/drizzle/migrations/0002_tighten_non_empty_description_name.sql
+++ b/app/drizzle/migrations/0002_tighten_non_empty_description_name.sql
@@ -1,0 +1,7 @@
+-- Backfill any empty strings before enforcing non-blank. `<> ''` mirrors the app's
+-- z.string().min(1); whitespace-only is deferred to the validation audit (#179).
+-- Both UPDATEs are idempotent: a re-run matches no rows.
+UPDATE "accounts" SET "account_name" = '(unnamed account)' WHERE "account_name" = '';--> statement-breakpoint
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_account_name_not_blank" CHECK (account_name <> '');--> statement-breakpoint
+UPDATE "transactions" SET "transaction_description" = '(no description)' WHERE "transaction_description" = '';--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_transaction_description_not_blank" CHECK (transaction_description <> '');

--- a/app/drizzle/migrations/meta/0002_snapshot.json
+++ b/app/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,759 @@
+{
+  "id": "fc8e4171-588d-4ddf-891d-66fd4c1ce759",
+  "prevId": "93f34131-75d9-48e0-8d72-77d8dccc3bb1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_balance_history": {
+      "name": "account_balance_history",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_date": {
+          "name": "balance_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_balance": {
+          "name": "daily_balance",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cumulative_balance": {
+          "name": "cumulative_balance",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {
+        "idx_abh_account_date": {
+          "name": "idx_abh_account_date",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "balance_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_balance_history_date": {
+          "name": "idx_balance_history_date",
+          "columns": [
+            {
+              "expression": "balance_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_balance_history_account_id_fkey": {
+          "name": "account_balance_history_account_id_fkey",
+          "tableFrom": "account_balance_history",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_balance_history_pkey": {
+          "name": "account_balance_history_pkey",
+          "columns": [
+            "account_id",
+            "balance_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_type_categories": {
+      "name": "account_type_categories",
+      "schema": "",
+      "columns": {
+        "account_type_category_id": {
+          "name": "account_type_category_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "account_type_categories_account_type_category_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "account_type_category": {
+          "name": "account_type_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_types": {
+      "name": "account_types",
+      "schema": "",
+      "columns": {
+        "account_type_id": {
+          "name": "account_type_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "account_types_account_type_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type_category_id": {
+          "name": "account_type_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liquidity_class": {
+          "name": "liquidity_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_types_account_type_category_id_fkey": {
+          "name": "account_types_account_type_category_id_fkey",
+          "tableFrom": "account_types",
+          "tableTo": "account_type_categories",
+          "columnsFrom": [
+            "account_type_category_id"
+          ],
+          "columnsTo": [
+            "account_type_category_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_types_liquidity_class_check": {
+          "name": "account_types_liquidity_class_check",
+          "value": "liquidity_class = ANY (ARRAY['liquid'::text, 'semi_liquid'::text, 'illiquid'::text, 'restricted'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type_id": {
+          "name": "account_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_identifier": {
+          "name": "account_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_date": {
+          "name": "closed_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_date": {
+          "name": "opened_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "liquidity_class": {
+          "name": "liquidity_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_account_type_id_fkey": {
+          "name": "accounts_account_type_id_fkey",
+          "tableFrom": "accounts",
+          "tableTo": "account_types",
+          "columnsFrom": [
+            "account_type_id"
+          ],
+          "columnsTo": [
+            "account_type_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "accounts_liquidity_class_check": {
+          "name": "accounts_liquidity_class_check",
+          "value": "liquidity_class = ANY (ARRAY['liquid'::text, 'semi_liquid'::text, 'illiquid'::text, 'restricted'::text])"
+        },
+        "accounts_account_name_not_blank": {
+          "name": "accounts_account_name_not_blank",
+          "value": "account_name <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transaction_categories": {
+      "name": "transaction_categories",
+      "schema": "",
+      "columns": {
+        "transaction_category_id": {
+          "name": "transaction_category_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "transaction_type_categories_transaction_type_category_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "transaction_category": {
+          "name": "transaction_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_types": {
+      "name": "transaction_types",
+      "schema": "",
+      "columns": {
+        "transaction_type_id": {
+          "name": "transaction_type_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "transaction_types_transaction_type_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_description": {
+          "name": "transaction_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_date": {
+          "name": "transaction_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_account_id": {
+          "name": "related_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type_id": {
+          "name": "transaction_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_category_id": {
+          "name": "transaction_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_transactions_account_date": {
+          "name": "idx_transactions_account_date",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "transaction_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_transactions_category": {
+          "name": "idx_transactions_category",
+          "columns": [
+            {
+              "expression": "transaction_category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_transactions_date": {
+          "name": "idx_transactions_date",
+          "columns": [
+            {
+              "expression": "transaction_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "date_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_transactions_related_account_id": {
+          "name": "idx_transactions_related_account_id",
+          "columns": [
+            {
+              "expression": "related_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"related_account_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_transactions_type": {
+          "name": "idx_transactions_type",
+          "columns": [
+            {
+              "expression": "transaction_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_fkey": {
+          "name": "transactions_account_id_fkey",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_related_account_id_fkey": {
+          "name": "transactions_related_account_id_fkey",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "related_account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_transaction_category_id_fkey": {
+          "name": "transactions_transaction_category_id_fkey",
+          "tableFrom": "transactions",
+          "tableTo": "transaction_categories",
+          "columnsFrom": [
+            "transaction_category_id"
+          ],
+          "columnsTo": [
+            "transaction_category_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_transaction_type_id_fkey": {
+          "name": "transactions_transaction_type_id_fkey",
+          "tableFrom": "transactions",
+          "tableTo": "transaction_types",
+          "columnsFrom": [
+            "transaction_type_id"
+          ],
+          "columnsTo": [
+            "transaction_type_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transactions_transaction_description_not_blank": {
+          "name": "transactions_transaction_description_not_blank",
+          "value": "transaction_description <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.v_account_balances_current": {
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type_category": {
+          "name": "account_type_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type_category_id": {
+          "name": "account_type_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_date": {
+          "name": "balance_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT abh.account_id, a.account_name, at.account_type, atc.account_type_category, atc.account_type_category_id, abh.cumulative_balance AS current_balance, abh.balance_date FROM account_balance_history abh JOIN accounts a USING (account_id) JOIN account_types at USING (account_type_id) JOIN account_type_categories atc USING (account_type_category_id) WHERE abh.balance_date = (( SELECT max(account_balance_history.balance_date) AS max FROM account_balance_history WHERE account_balance_history.account_id = abh.account_id))",
+      "name": "v_account_balances_current",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.v_daily_totals": {
+      "columns": {
+        "transaction_date": {
+          "name": "transaction_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_total": {
+          "name": "daily_total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT t.transaction_date, tt.transaction_type, sum(t.amount) AS daily_total FROM transactions t JOIN transaction_types tt USING (transaction_type_id) GROUP BY t.transaction_date, tt.transaction_type",
+      "name": "v_daily_totals",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.v_transactions_full": {
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_description": {
+          "name": "transaction_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_date": {
+          "name": "transaction_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_account_id": {
+          "name": "related_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type_id": {
+          "name": "account_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type_category": {
+          "name": "account_type_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_account_name": {
+          "name": "related_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type_id": {
+          "name": "transaction_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_category_id": {
+          "name": "transaction_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_category": {
+          "name": "transaction_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT t.transaction_id, t.transaction_description, t.transaction_date, t.amount, t.account_id, t.related_account_id, a.account_name, a.account_type_id, at.account_type, atc.account_type_category, ra.account_name AS related_account_name, tt.transaction_type_id, tt.transaction_type, tc.transaction_category_id, tc.transaction_category FROM transactions t JOIN accounts a USING (account_id) JOIN account_types at USING (account_type_id) JOIN account_type_categories atc USING (account_type_category_id) LEFT JOIN accounts ra ON t.related_account_id = ra.account_id JOIN transaction_types tt USING (transaction_type_id) JOIN transaction_categories tc USING (transaction_category_id)",
+      "name": "v_transactions_full",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780365958133,
       "tag": "0001_add_indexes_related_account_and_abh",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783478173167,
+      "tag": "0002_tighten_non_empty_description_name",
+      "breakpoints": true
     }
   ]
 }

--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -38,6 +38,7 @@ export const transactions = pgTable("transactions", {
 			foreignColumns: [transactionTypes.transactionTypeId],
 			name: "transactions_transaction_type_id_fkey"
 		}),
+	check("transactions_transaction_description_not_blank", sql`transaction_description <> ''`),
 ]);
 
 export const accountTypes = pgTable("account_types", {
@@ -69,6 +70,7 @@ export const accounts = pgTable("accounts", {
 			name: "accounts_account_type_id_fkey"
 		}),
 	check("accounts_liquidity_class_check", sql`liquidity_class = ANY (ARRAY['liquid'::text, 'semi_liquid'::text, 'illiquid'::text, 'restricted'::text])`),
+	check("accounts_account_name_not_blank", sql`account_name <> ''`),
 ]);
 
 export const accountTypeCategories = pgTable("account_type_categories", {

--- a/app/tests/integration/actions/account.test.ts
+++ b/app/tests/integration/actions/account.test.ts
@@ -83,6 +83,14 @@ describe("createAccount", () => {
     expect(result.errors).toHaveProperty("accountName");
   });
 
+  // The DB backstop for the above (issue #147): even a direct insert bypassing
+  // validation is rejected by the non-blank CHECK constraint (Postgres 23514).
+  it("rejects a direct insert with an empty account name", async () => {
+    await expect(
+      db.insert(accounts).values({ accountName: "", accountTypeId: 1 })
+    ).rejects.toMatchObject({ cause: { code: "23514" } });
+  });
+
   it("returns error for invalid accountTypeId", async () => {
     const fd = makeFormData({ accountName: "Test", accountTypeId: "0" });
     const result = await createAccount(emptyState, fd);

--- a/app/tests/integration/actions/transaction.test.ts
+++ b/app/tests/integration/actions/transaction.test.ts
@@ -455,3 +455,20 @@ describe("deleteTransaction", () => {
     expect(result.message).toBe("Invalid transaction ID");
   });
 });
+
+// ─── non-blank CHECK constraint (issue #147) ─────────────────────────────────
+
+describe("transactions_transaction_description_not_blank", () => {
+  it("rejects a direct insert with an empty description (Postgres check violation 23514)", async () => {
+    await expect(
+      db.insert(transactions).values({
+        transactionDescription: "",
+        transactionDate: "2024-03-15",
+        accountId: testAccountId,
+        amount: "1.00",
+        transactionTypeId: 1,
+        transactionCategoryId: 1,
+      })
+    ).rejects.toMatchObject({ cause: { code: "23514" } });
+  });
+});


### PR DESCRIPTION
Closes #147.

## Headline finding

The columns #147 names — `transaction_description`, `account_name`, and the app-required FK columns — were **already `NOT NULL` and already FK-constrained** (in `schema.ts`, the `0000_baseline` migration, and every historical pre-Drizzle schema). The only nullable FK is `transactions.related_account_id`, which is intentionally nullable and out of scope.

So the literal NOT NULL/FK acceptance criteria were already satisfied. The genuine remaining drift — the "silent bad data" the issue's Context points at — is that **`NOT NULL` still permits the empty string `''`**, while the app's Zod validators require `.min(1)`. An out-of-band write (psql, importer bug, future code path) with `transaction_description = ''` / `account_name = ''` passes the DB but violates the app's contract.

## Change

Migration `0002` adds two `CHECK` constraints:

- `transactions_transaction_description_not_blank` — `CHECK (transaction_description <> '')`
- `accounts_account_name_not_blank` — `CHECK (account_name <> '')`

Declared via the `check()` helper in `schema.ts` so the CI schema-drift gate stays green. The migration **backfills** any pre-existing empty rows to a sentinel (`'(no description)'` / `'(unnamed account)'`) before adding each constraint; the backfill is idempotent.

**Predicate `<> ''`, not `btrim(...)`:** `z.string().min(1)` accepts a whitespace-only string, so a `btrim` check would let the DB reject a value the app currently permits (surfacing as a runtime insert failure). `<> ''` mirrors the app exactly and rejects only what `NOT NULL` misses. The whitespace-only case is deferred to the input-validation audit (#179).

## Testing

- New DB-level integration tests in `transaction.test.ts` / `account.test.ts`: a direct insert with an empty string is rejected with Postgres check-violation `23514`.
- Existing app-path validation tests (empty input rejected at the Zod layer) unchanged.
- Full suite: **306/306 pass**; lint clean.

## Verification performed

- Schema-drift gate green: `db:generate` reports "No schema changes".
- Migration applied to both `Finances` and `Finances_Test`; constraints confirmed via `pg_constraint`.
- Constraint proven live: raw `INSERT` of `transaction_description = ''` errors with `violates check constraint`.

## Acceptance criteria

- [x] `transaction_description`, `account_name`, identified FK columns are NOT NULL (already were; verified) + empty-string now also rejected
- [x] Pre-migration data check + backfill documented (guarded `UPDATE` in `0002`, audit query in the plan)
- [x] App tests green post-migration

## Note for reviewers

The `migrate` Compose service builds an image — a plain `docker compose run --rm migrate` can use a stale image and silently skip a new migration; `docker compose build migrate` first. Worth keeping in mind for CI/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)