### PR TITLE
Issue #122 - Add scheduled database backup & disaster recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,10 @@ FINANCE_APP_DB=Finances
 # Secret used by Auth.js to sign/encrypt session JWTs (Issue #120).
 # Required by finance-app. Generate one with: openssl rand -base64 33
 AUTH_SECRET=changeme-generate-with-openssl-rand-base64-33
+
+# Backups (Issue #122) — the pg-backup service dumps these to ./backups/.
+# BACKUP_DBS is a comma-separated list; keep it in sync with FINANCE_APP_DB
+# and MB_DB_DBNAME above if you customize those names.
+BACKUP_DBS=Finances,metabase
+BACKUP_RETENTION_DAYS=14
+BACKUP_INTERVAL_SECONDS=86400

--- a/.github/workflows/backup-smoke.yml
+++ b/.github/workflows/backup-smoke.yml
@@ -1,0 +1,101 @@
+name: Backup smoke
+
+# Proves the backup + restore round-trip works end-to-end, so silent backup
+# corruption or a script regression is caught. GitHub runners cannot see the
+# deployment host's ./backups/, so this job self-produces a dump from a known
+# seeded dataset, restores it into a throwaway database, and asserts a known
+# row count. (Verifying the *real* host dumps depends on phase-2 off-site
+# upload — see docs/backups.md.)
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'        # Mondays 06:00 UTC
+  workflow_dispatch:            # Manual runs
+  pull_request:                 # Also guard PRs that touch the scripts/workflow
+    paths:
+      - 'scripts/backup.sh'
+      - 'scripts/restore.sh'
+      - '.github/workflows/backup-smoke.yml'
+
+jobs:
+  backup-smoke:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: changeme
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: changeme
+      BACKUP_DIR: ${{ github.workspace }}/backups
+      BACKUP_DBS: Finances
+      BACKUP_RETENTION_DAYS: 3650   # Never prune within this short-lived job
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Shellcheck backup/restore scripts
+        run: shellcheck scripts/backup.sh scripts/restore.sh
+
+      - name: Install PostgreSQL 18 client
+        # pg_dump must be >= the server major version (18); the runner's default
+        # client can be older, so install the matching client from PGDG.
+        run: |
+          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-18
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install app dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Create Finances database
+        run: psql -c 'CREATE DATABASE "Finances";'
+
+      - name: Apply Drizzle migrations
+        working-directory: app
+        env:
+          DATABASE_URL: postgresql://postgres:changeme@localhost:5432/Finances
+        run: npm run db:migrate
+
+      - name: Seed Finances with a known dataset
+        run: |
+          psql -d Finances -f init-db/seeds/shared-lookups.sql
+          psql -d Finances -f init-db/seeds/finances-test-mock-data.sql
+          psql -d Finances -f init-db/seeds/rebuild-balance-history.sql
+
+      - name: Back up Finances
+        run: ./scripts/backup.sh
+
+      - name: Restore the latest Finances dump into a throwaway database
+        run: ./scripts/restore.sh --force Finances Finances_Restore_Check
+
+      - name: Assert known row count survived the round-trip
+        run: |
+          count="$(psql -d Finances_Restore_Check -tAc 'SELECT COUNT(*) FROM accounts;')"
+          echo "accounts in restored database: $count"
+          if [ "$count" != "8" ]; then
+            echo "::error::Expected 8 accounts after restore, got $count — backup/restore round-trip is broken"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ __pycache__/
 # Credentials — never commit
 .env
 
+# Database backups — contain financial data, never commit
+/backups/*
+!/backups/.gitkeep
+
 # Next.js application (app/ directory)
 app/node_modules
 app/.next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Scheduled database backups: a default-on `pg-backup` Compose service runs `pg_dump` (custom format) of the `Finances` and `metabase` databases into `./backups/` on an interval (default daily) with retention pruning, plus `scripts/backup.sh` / `scripts/restore.sh` (one-command restore into a clean DB, guarded against clobbering production DBs without `--force`) and a weekly `backup-smoke` CI workflow that seeds a known dataset, dumps it, restores it, and asserts a known row count to catch silent backup corruption. Documented in the new [docs/backups.md](docs/backups.md); tunable via `BACKUP_DBS` / `BACKUP_RETENTION_DAYS` / `BACKUP_INTERVAL_SECONDS` (see `.env.example`) ([Issue #122](https://github.com/aellington89/finance-stack/issues/122)).
 - Session-based authentication (Auth.js/NextAuth v5, Credentials provider, JWT sessions): a sign-in page at `/login`, a sign-out control in the sidebar footer, a `users` table (authored migration `0003_add_users_table`) storing scrypt password hashes, and a first-user/password-reset CLI (`npm run auth:create-user -- <username>`). Requires a new `AUTH_SECRET` env var (see `.env.example` / `app/.env.local.example`) — documented in the new [docs/auth.md](docs/auth.md) ([Issue #120](https://github.com/aellington89/finance-stack/issues/120)).
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ docker compose down
 
 Data is persisted in Docker volumes and will be available on next startup.
 
+## Backups
+
+The `pg-backup` service runs a scheduled `pg_dump` of the `Finances` and
+`metabase` databases into `./backups/` (default daily, 14-day retention). It
+starts automatically with `docker compose up`. Restore the newest dump into a
+throwaway database with:
+
+```bash
+docker compose exec pg-backup /scripts/restore.sh --force Finances Finances_Restore_Check
+```
+
+See [docs/backups.md](docs/backups.md) for configuration, full disaster
+recovery, and the weekly restore-smoke CI check.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev workflow, commit conventions, CI gates, changelog habits, and the release process.
@@ -123,6 +137,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev workflow, commit conventions,
 - [Contributing](CONTRIBUTING.md) — dev workflow, conventions, and the release process
 - [Authentication](docs/auth.md) — the auth model, first-user CLI, `AUTH_SECRET`, and password resets
 - [Database](docs/database.md) — schema, views, balance history, first-launch init, and the test database
+- [Backups](docs/backups.md) — the scheduled backup service, retention, and disaster recovery
 - [Schema Changes](docs/schema-changes.md) — making schema changes and adopting migrations on existing databases
 - [Testing](docs/testing.md) — running tests and the static lookup-table fixtures
 - [Importer](docs/importer.md) — the importer service and adding new import types

--- a/backups/.gitkeep
+++ b/backups/.gitkeep
@@ -1,0 +1,3 @@
+# Database dump output directory (see docs/backups.md).
+# Dumps are gitignored — this file only keeps the bind-mount target
+# present in a fresh clone so `docker compose up` can mount it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,57 @@ services:
       com.finance-stack.component: "importer"
       com.finance-stack.description: "File importer service"
 
+  # Scheduled logical backups. Runs pg_dump (custom format) of each database in
+  # BACKUP_DBS to ./backups/ on a loop, pruning dumps older than the retention
+  # window. Reuses the postgres:18.0 image so pg_dump stays version-matched to
+  # the server. Restore a dump with scripts/restore.sh. See docs/backups.md.
+  pg-backup:
+    image: postgres:18.0
+    container_name: pg-backup
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy   # Only needs a reachable DB, not the app
+    environment:
+      PGHOST: postgres
+      PGPORT: 5432
+      PGUSER: ${POSTGRES_USER}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      # Defaults track the configured DB names; override with BACKUP_DBS in .env
+      BACKUP_DBS: ${BACKUP_DBS:-${FINANCE_APP_DB:-Finances},${MB_DB_DBNAME:-metabase}}
+      BACKUP_DIR: /backups
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+      BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-86400}
+    volumes:
+      - ./scripts:/scripts:ro        # Read-only — container should not modify scripts
+      - ./backups:/backups           # Host-visible dump output (gitignored — financial data)
+    entrypoint: >
+      bash -c "
+      set -uo pipefail;
+      echo \"pg-backup ready — dumping [$${BACKUP_DBS}] every $${BACKUP_INTERVAL_SECONDS}s, retention $${BACKUP_RETENTION_DAYS}d\";
+      while true; do
+        /scripts/backup.sh || echo '[backup] run failed — will retry next cycle';
+        sleep \"$${BACKUP_INTERVAL_SECONDS}\";
+      done
+      "
+    networks:
+      - appnet
+    logging: *default-logging
+    healthcheck:                     # Unhealthy if no dump is newer than 1.5x the interval (stalled loop)
+      test: ["CMD-SHELL", "find \"$${BACKUP_DIR}\" -name '*.dump' -mmin -$$(( BACKUP_INTERVAL_SECONDS * 3 / 2 / 60 + 1 )) | grep -q . || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 60s              # First dump runs at container start; allow time to land
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
+    labels:
+      com.finance-stack.component: "backup"
+      com.finance-stack.description: "Scheduled pg_dump backups with retention pruning"
+
   # Metabase BI tool for dashboards and ad-hoc analytics against the Finances database.
   # Stores its own internal metadata (questions, dashboards, users) in a separate metabase DB.
   metabase:

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,95 @@
+# Backups & disaster recovery
+
+Covers the scheduled backup service, where dumps live, retention, and how to
+restore.
+
+## Overview
+
+The `pg-backup` service runs a scheduled `pg_dump` of each configured database
+into `./backups/` on the host, pruning old dumps on a retention window. It runs
+by default (`docker compose up`) alongside Postgres and reuses the
+`postgres:18.0` image, so `pg_dump`/`pg_restore` stay version-matched to the
+server.
+
+Dumps use PostgreSQL's **custom format** (`pg_dump -Fc`): compressed and
+restorable with `pg_restore`. Files are named `<db>_<UTC-timestamp>.dump`, e.g.
+`Finances_20260711T060000Z.dump`.
+
+> **Backups contain financial data.** `./backups/` is gitignored and never
+> committed. Off-site/encrypted storage is a separate phase-2 concern (see
+> [below](#off-site-phase-2)).
+
+## Configuration
+
+Set in `.env` (see `.env.example`):
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `BACKUP_DBS` | `Finances,metabase` | Comma-separated databases to dump. Keep in sync with `FINANCE_APP_DB` / `MB_DB_DBNAME` if you rename them. |
+| `BACKUP_RETENTION_DAYS` | `14` | Dumps older than this are pruned — but the newest dump of each database is always kept. |
+| `BACKUP_INTERVAL_SECONDS` | `86400` | Seconds between backup runs (default daily). |
+
+The service dumps once at start and then every `BACKUP_INTERVAL_SECONDS`. Its
+Docker healthcheck reports **unhealthy** if no dump is newer than 1.5× the
+interval — a quick signal that the backup loop has stalled.
+
+## Where dumps land
+
+`./backups/` in the repo root (bind-mounted into the service at `/backups`).
+List them with:
+
+```bash
+ls -lt backups/
+```
+
+## Restoring
+
+`scripts/restore.sh` drops and recreates the target database, then applies the
+dump. It runs inside the running Postgres container so no local client is
+needed:
+
+```bash
+# Restore the newest Finances dump into a throwaway database to verify it:
+docker compose exec pg-backup /scripts/restore.sh --force Finances Finances_Restore_Check
+```
+
+Usage: `restore.sh [--force] [DUMP_FILE] [TARGET_DB]`
+
+- `DUMP_FILE` can be a path, a bare filename in `/backups`, a **database name**
+  (→ newest dump of that DB), or `latest`/omitted (→ newest dump across all
+  databases — ambiguous when several DBs are backed up, so prefer the DB name).
+- `TARGET_DB` omitted → derived from the dump's filename prefix (or
+  `RESTORE_TARGET_DB`).
+- `--force` is **required** to restore over a production database
+  (`Finances` / `metabase`), since the target is dropped and recreated.
+
+### Full disaster recovery (restore over the live database)
+
+```bash
+# Restores the latest Finances dump back over the production Finances database.
+# This DROPS the current Finances DB first — be sure.
+docker compose exec pg-backup /scripts/restore.sh --force \
+  /backups/Finances_<timestamp>.dump Finances
+```
+
+For a from-scratch rebuild (lost volume), bring the stack up so the databases
+are created and migrated, then run the restore above.
+
+## Verification (CI)
+
+`.github/workflows/backup-smoke.yml` runs weekly (and on PRs touching the backup
+scripts). It seeds a known dataset, runs `backup.sh`, restores the dump into a
+throwaway database, and asserts a known row count — catching silent dump/restore
+corruption and script regressions.
+
+Because GitHub runners can't reach the deployment host's `./backups/`, the job
+verifies the backup/restore **scripts and round-trip**, not a specific host's
+dumps.
+
+## Off-site (phase 2)
+
+Off-host, encrypted storage (S3/B2/rclone) and WAL archiving / point-in-time
+recovery are out of scope here. `scripts/backup.sh` exposes a `BACKUP_POST_HOOK`
+extension point — set it to an executable that ships the fresh dumps off-host
+after each run. When the off-site feature is built, the smoke check should be
+extended to verify the real uploaded dumps.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -190,7 +190,9 @@ finance-stack/
 │   ├── poll.py                            # Polling loop and parser dispatcher (committed)
 │   └── parsers/                           # One module per import type (gitignored)
 ├── imports/                               # Drop folders — one per import type (gitignored)
+├── backups/                               # pg_dump output from the pg-backup service (contents gitignored)
 ├── .github/workflows/ci.yml             # CI: schema-drift + seed-reference gates, lint, unit + integration tests
+├── .github/workflows/backup-smoke.yml   # CI: weekly backup + restore round-trip smoke test (#122)
 ├── .vscode/extensions.json              # Recommended VS Code extensions for this project
 ├── init-db/
 │   ├── 01-create-databases.sh            # First-run DB + Metabase role creation only (auto-runs on empty data dir)
@@ -199,5 +201,7 @@ finance-stack/
 │       ├── finances-test-mock-data.sql   # account_types, transaction_categories, accounts, ~400 txns (Finances_Test only)
 │       └── rebuild-balance-history.sql   # Balance history rebuild for Finances_Test post-seed
 └── scripts/
-    └── update-account-balance-history.sql   # Balance history rebuild script (manual / --profile init)
+    ├── update-account-balance-history.sql   # Balance history rebuild script (manual / --profile init)
+    ├── backup.sh                            # Scheduled pg_dump with retention pruning (pg-backup service)
+    └── restore.sh                           # Restore a dump into a clean database (#122)
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,6 +95,7 @@ merges.
 - [#133](https://github.com/aellington89/finance-stack/issues/133) Pre-commit hooks + Makefile
 - [#141](https://github.com/aellington89/finance-stack/issues/141) E2E tests with Playwright *(recommended before v1.0.0)*
 - [#142](https://github.com/aellington89/finance-stack/issues/142) Coverage thresholds in vitest.config.ts *(recommended before v1.0.0)*
+- [#185](https://github.com/aellington89/finance-stack/issues/185) Audit docker-compose services: necessity & profile gating *(new)*
 
 ### v1.2.0 — Phase 4 (Performance polish)
 - [#125](https://github.com/aellington89/finance-stack/issues/125) Suspense + loading.tsx + not-found.tsx

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Scheduled logical backup of the finance-stack databases.
+#
+# Runs a compressed pg_dump (custom format, -Fc) of each database
+# listed in BACKUP_DBS into BACKUP_DIR, then prunes dumps older
+# than BACKUP_RETENTION_DAYS — always keeping at least the newest
+# dump of each database, so a paused stack never prunes itself to
+# zero.
+#
+# Invoked on a loop by the pg-backup service in docker-compose.yml
+# (and once per run by the weekly backup-smoke CI job). Restore a
+# dump with scripts/restore.sh.
+#
+# Custom format (-Fc) is chosen so restore.sh can use pg_restore
+# (compressed, selective, --no-owner). Running this from the
+# postgres:18.0 image keeps pg_dump version-matched to the server,
+# avoiding cross-major-version dump failures.
+#
+# Environment (all have sensible defaults except credentials):
+#   PGHOST                 Postgres host                (default: postgres)
+#   PGPORT                 Postgres port                (default: 5432)
+#   PGUSER                 Postgres superuser           (required)
+#   PGPASSWORD             Password for PGUSER          (required)
+#   BACKUP_DBS             Comma-separated DB names     (default: Finances)
+#   BACKUP_DIR             Output directory             (default: /backups)
+#   BACKUP_RETENTION_DAYS  Prune dumps older than N days(default: 14)
+#   BACKUP_POST_HOOK       Optional path to a script run after each
+#                          successful run — the phase-2 off-site seam.
+# ------------------------------------------------------------
+set -euo pipefail
+
+PGHOST="${PGHOST:-postgres}"
+PGPORT="${PGPORT:-5432}"
+BACKUP_DBS="${BACKUP_DBS:-Finances}"
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
+
+export PGHOST PGPORT
+
+log() { echo "[backup] $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
+
+mkdir -p "$BACKUP_DIR"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+
+# Split the comma-separated list into an array (trims surrounding spaces).
+IFS=',' read -ra dbs <<< "$BACKUP_DBS"
+
+dumped=0
+for raw in "${dbs[@]}"; do
+  db="$(echo "$raw" | xargs)"   # trim whitespace
+  [ -z "$db" ] && continue
+
+  # Skip (don't fail the whole run) if the database doesn't exist —
+  # e.g. metabase before its first init on a partial stack.
+  if ! psql -U "$PGUSER" -d postgres -tAc \
+        "SELECT 1 FROM pg_database WHERE datname = '${db}'" | grep -q 1; then
+    log "WARNING: database '${db}' does not exist — skipping"
+    continue
+  fi
+
+  final="${BACKUP_DIR}/${db}_${timestamp}.dump"
+  tmp="${final}.tmp"
+
+  log "dumping '${db}' -> $(basename "$final")"
+  # Dump to a .tmp name first, then atomically rename — a crash mid-dump
+  # never leaves a file that looks like a complete backup.
+  pg_dump -U "$PGUSER" -d "$db" -Fc -f "$tmp"
+  mv "$tmp" "$final"
+  dumped=$((dumped + 1))
+
+  # Retention prune for this DB, but never delete its newest dump.
+  # SC2012: dump filenames are controlled (db name + UTC timestamp, no spaces
+  # or newlines), so time-sorting with ls is safe and simpler than find here.
+  # shellcheck disable=SC2012
+  newest="$(ls -1t "${BACKUP_DIR}/${db}_"*.dump 2>/dev/null | head -n1 || true)"
+  while IFS= read -r old; do
+    [ -z "$old" ] && continue
+    [ "$old" = "$newest" ] && continue   # safety floor: keep the latest
+    log "pruning aged dump $(basename "$old")"
+    rm -f "$old"
+  done < <(find "$BACKUP_DIR" -maxdepth 1 -name "${db}_*.dump" -type f \
+             -mtime "+${BACKUP_RETENTION_DAYS}" 2>/dev/null)
+done
+
+if [ "$dumped" -eq 0 ]; then
+  log "ERROR: no databases were dumped (check BACKUP_DBS='${BACKUP_DBS}')"
+  exit 1
+fi
+
+# Phase-2 off-site seam: if a post-hook is configured, run it so the fresh
+# dumps can be shipped off-host (S3/B2/rclone). No-op by default.
+if [ -n "${BACKUP_POST_HOOK:-}" ] && [ -x "${BACKUP_POST_HOOK}" ]; then
+  log "running BACKUP_POST_HOOK ${BACKUP_POST_HOOK}"
+  "${BACKUP_POST_HOOK}" "$BACKUP_DIR"
+fi
+
+log "done — ${dumped} database(s) dumped to ${BACKUP_DIR}"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Restore a finance-stack database dump into a clean database.
+#
+# Usage:
+#   scripts/restore.sh [--force] [DUMP_FILE] [TARGET_DB]
+#
+#   DUMP_FILE   One of:
+#                 - a path to a .dump produced by scripts/backup.sh, or
+#                 - a bare filename inside BACKUP_DIR, or
+#                 - a database name (e.g. "Finances") → newest dump of that DB, or
+#                 - "latest" / omitted → newest dump across all databases.
+#   TARGET_DB   Database to restore into. Omitted → derived from the
+#               dump's filename prefix (e.g. Finances_2026….dump →
+#               "Finances"), or RESTORE_TARGET_DB if set.
+#   --force     Required to restore over a production database name
+#               (Finances / metabase). Destructive — the target DB is
+#               dropped and recreated first.
+#
+# The target database is DROPPED and RECREATED, then the dump is
+# applied with pg_restore --no-owner. Connections to the target are
+# terminated first so the DROP can proceed.
+#
+# Environment:
+#   PGHOST                Postgres host          (default: postgres)
+#   PGPORT                Postgres port          (default: 5432)
+#   PGUSER                Postgres superuser     (required)
+#   PGPASSWORD            Password for PGUSER    (required)
+#   BACKUP_DIR            Where dumps live       (default: /backups)
+#   RESTORE_TARGET_DB     Default target DB when not derivable
+# ------------------------------------------------------------
+set -euo pipefail
+
+PGHOST="${PGHOST:-postgres}"
+PGPORT="${PGPORT:-5432}"
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+export PGHOST PGPORT
+
+log() { echo "[restore] $*"; }
+die() { echo "[restore] ERROR: $*" >&2; exit 1; }
+
+# Databases that must not be clobbered without --force.
+PROTECTED_DBS="Finances metabase"
+
+force=0
+args=()
+for a in "$@"; do
+  if [ "$a" = "--force" ]; then
+    force=1
+  else
+    args+=("$a")
+  fi
+done
+
+dump_arg="${args[0]:-}"
+target_db="${args[1]:-}"
+
+# Resolve the dump to restore. SC2012: dump filenames are controlled
+# (db name + UTC timestamp, no spaces/newlines), so time-sorting with ls is safe.
+if [ -z "$dump_arg" ] || [ "$dump_arg" = "latest" ]; then
+  # Newest dump across all databases. Ambiguous when several DBs are backed up —
+  # prefer naming the database (below) when you have more than one.
+  # shellcheck disable=SC2012
+  dump_file="$(ls -1t "${BACKUP_DIR}/"*.dump 2>/dev/null | head -n1 || true)"
+  [ -z "$dump_file" ] && die "no dump given and no *.dump found in ${BACKUP_DIR}"
+  log "using newest dump: $(basename "$dump_file")"
+elif [ -f "$dump_arg" ]; then
+  dump_file="$dump_arg"                       # explicit path
+elif [ -f "${BACKUP_DIR}/${dump_arg}" ]; then
+  dump_file="${BACKUP_DIR}/${dump_arg}"       # bare filename inside BACKUP_DIR
+else
+  # Treat as a database name: newest <name>_*.dump in BACKUP_DIR.
+  # shellcheck disable=SC2012
+  dump_file="$(ls -1t "${BACKUP_DIR}/${dump_arg}_"*.dump 2>/dev/null | head -n1 || true)"
+  [ -z "$dump_file" ] && die "no dump file or database series matching '${dump_arg}' in ${BACKUP_DIR}"
+  log "using newest '${dump_arg}' dump: $(basename "$dump_file")"
+fi
+[ -f "$dump_file" ] || die "dump file not found: ${dump_file}"
+
+# Default target: prefix of the dump filename (before the first "_"),
+# or RESTORE_TARGET_DB.
+if [ -z "$target_db" ]; then
+  if [ -n "${RESTORE_TARGET_DB:-}" ]; then
+    target_db="$RESTORE_TARGET_DB"
+  else
+    base="$(basename "$dump_file")"
+    target_db="${base%%_*}"
+  fi
+  log "no target DB specified — using: ${target_db}"
+fi
+
+# Guard against clobbering a production database without --force.
+for p in $PROTECTED_DBS; do
+  if [ "$target_db" = "$p" ] && [ "$force" -ne 1 ]; then
+    die "refusing to overwrite protected database '${target_db}' without --force"
+  fi
+done
+
+log "restoring $(basename "$dump_file") -> database '${target_db}' on ${PGHOST}:${PGPORT}"
+
+# Terminate open connections so DROP DATABASE can proceed, then recreate.
+psql -U "$PGUSER" -d postgres -v ON_ERROR_STOP=1 <<SQL
+SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity
+ WHERE datname = '${target_db}' AND pid <> pg_backend_pid();
+DROP DATABASE IF EXISTS "${target_db}";
+CREATE DATABASE "${target_db}";
+SQL
+
+pg_restore --no-owner -U "$PGUSER" -d "$target_db" "$dump_file"
+
+log "done — restored into '${target_db}'"


### PR DESCRIPTION
Closes #122.

## What this adds

A default-on `pg-backup` Compose sidecar (reuses `postgres:18.0`, so `pg_dump`/`pg_restore` stay version-matched to the server) that dumps the `Finances` and `metabase` databases into `./backups/` on an interval, with retention pruning — plus one-command backup/restore scripts, a CI round-trip smoke test, and docs.

### Changes
- **`scripts/backup.sh`** — `pg_dump -Fc` per database, atomic temp-then-rename, per-DB retention pruning with a "keep newest" safety floor, missing-DB skip, and a `BACKUP_POST_HOOK` seam for phase-2 off-site upload.
- **`scripts/restore.sh`** — one-command restore; dump selector accepts a path, a bare filename, a **database name** (newest dump of that DB), or `latest`; drops+recreates the target; `--force` guard protects `Finances`/`metabase`.
- **`docker-compose.yml`** — default-on `pg-backup` service, interval loop, resource limits, stale-dump healthcheck; `BACKUP_DBS` defaults track `FINANCE_APP_DB`/`MB_DB_DBNAME`.
- **`.github/workflows/backup-smoke.yml`** — weekly + PR-on-scripts job: shellcheck → seed → backup → restore → assert `accounts = 8`. Installs the PG18 client so `pg_dump` is version-matched.
- **Supporting** — `.gitignore` + `backups/.gitkeep`, `.env.example` block, `docs/backups.md`, README "Backups" section, `docs/project-structure.md` tree, `CHANGELOG.md` `[Unreleased]` bullet.

## Acceptance criteria
- [x] Scheduled dump lands in `./backups/` with retention pruning
- [x] `scripts/restore.sh` restores a dump into a clean DB in one command
- [x] Weekly CI job restores latest dump and asserts a known row count
- [x] README documents backup location and restore steps

## Verification
Exercised end-to-end against a live stack (real data untouched — restore targeted a throwaway DB only):
- Dumps land for both `Finances` and `metabase`; interval loop ticks; healthcheck `healthy`.
- Restore round-trip is exact (36/36 accounts, 4720/4720 transactions).
- `--force` guard refuses to clobber `Finances`; retention prune removes aged dumps while keeping the newest.
- shellcheck clean.

## Out of scope (phase 2)
Off-site/encrypted storage and WAL/PITR. `backup.sh` leaves a `BACKUP_POST_HOOK` seam; `docs/backups.md` notes the phase-2 work should extend CI to verify real host dumps.

## Follow-up
Filed #185 (Audit docker-compose services: necessity & profile gating), Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)