### PR TITLE
Issue #130 - Lock down Postgres surface area

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,25 @@
 # Environment variables for the finance stack.
 # Copy this file to .env and replace placeholder values before starting the stack.
 
-# PostgreSQL
+# PostgreSQL superuser — used only by the maintenance jobs (migrate, init-script,
+# pg-backup), never by the long-running services.
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=postgres
+
+# Least-privilege service roles (Issue #130). Required — the migrate service
+# aborts if any of these is empty rather than creating a login role with a blank
+# password. The roles themselves (finance_app, finance_importer,
+# finance_metabase) are created and granted automatically on every
+# `docker compose up`; see docs/database.md for the grant matrix.
+#
+# These go into URL-form connection strings, so use URL-safe characters or
+# percent-encode them (the same constraint POSTGRES_PASSWORD already has:
+# a literal @ : / ? # in a password will break the URL).
+FINANCE_APP_DB_PASSWORD=changeme
+FINANCE_IMPORTER_DB_PASSWORD=changeme
+# Entered by hand in the Metabase admin UI, not consumed by docker-compose.yml.
+FINANCE_METABASE_DB_PASSWORD=changeme
 
 # Metabase internal metadata database
 MB_DB_DBNAME=metabase
@@ -27,6 +42,7 @@ AUTH_SECRET=changeme-generate-with-openssl-rand-base64-33
 # Backups (Issue #122) — the pg-backup service dumps these to ./backups/.
 # BACKUP_DBS is a comma-separated list; keep it in sync with FINANCE_APP_DB
 # and MB_DB_DBNAME above if you customize those names.
+# These are optional for the .env file. All three have defaults in docker-compose.yml, but you can override them here if you want to change the retention period or interval.
 BACKUP_DBS=Finances,metabase
 BACKUP_RETENTION_DAYS=14
 BACKUP_INTERVAL_SECONDS=86400

--- a/.github/workflows/backup-smoke.yml
+++ b/.github/workflows/backup-smoke.yml
@@ -48,8 +48,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Shellcheck backup/restore scripts
-        run: shellcheck scripts/backup.sh scripts/restore.sh
+      - name: Shellcheck scripts/
+        run: shellcheck scripts/backup.sh scripts/restore.sh scripts/verify-db-roles.sh
 
       - name: Install PostgreSQL 18 client
         # pg_dump must be >= the server major version (18); the runner's default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,40 @@ jobs:
           psql -h localhost -U postgres -d "Finances_Test" -f ../init-db/seeds/finances-test-mock-data.sql
           psql -h localhost -U postgres -d "Finances_Test" -f ../init-db/seeds/rebuild-balance-history.sql
 
+      # Issue #130. CI's postgres service is a bare image — it never runs
+      # init-db — so create the roles and apply the grants explicitly. These are
+      # the exact files the migrate service runs against the real databases: one
+      # authority, exercised twice.
+      - name: Create service roles and apply grants
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: changeme
+        run: |
+          psql -v ON_ERROR_STOP=1 -d postgres \
+            -v app_password=ci-app-pw \
+            -v importer_password=ci-importer-pw \
+            -v metabase_password=ci-metabase-pw \
+            -f ../init-db/roles/01-create-roles.sql
+          psql -v ON_ERROR_STOP=1 -d "Finances_Test" \
+            -v OWNER=postgres -f ../init-db/roles/02-grants.sql
+
+      # Asserts the grant matrix against the catalog, then connects as each role
+      # and runs real statements (see scripts/verify-db-roles.sh). PGHOST is
+      # localhost, which reaches the service container through Docker's port
+      # forwarding and so authenticates with a password — a `trust` path would
+      # make the credential half of this check vacuous.
+      - name: Role privilege gate
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: changeme
+          FINANCE_APP_DB_PASSWORD: ci-app-pw
+          FINANCE_IMPORTER_DB_PASSWORD: ci-importer-pw
+          FINANCE_METABASE_DB_PASSWORD: ci-metabase-pw
+          ROLES_DIR: ../init-db/roles
+        run: bash ../scripts/verify-db-roles.sh Finances_Test
+
       - name: Schema drift gate
         env:
           DATABASE_URL: postgresql://postgres:changeme@localhost:5432/Finances_Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,13 @@ jobs:
           MB_DB_PASS: changeme
           MB_DB_DBNAME: metabase
           AUTH_SECRET: release-smoke-test-only-secret
+          # Required by the migrate service, which creates the least-privilege
+          # service roles (#130) and aborts on an empty password. finance-app and
+          # importer authenticate with these, so the health poll below only turns
+          # 200 if the roles were created and granted correctly.
+          FINANCE_APP_DB_PASSWORD: release-smoke-app-pw
+          FINANCE_IMPORTER_DB_PASSWORD: release-smoke-importer-pw
+          FINANCE_METABASE_DB_PASSWORD: release-smoke-metabase-pw
         run: |
           docker compose up -d
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Required new configuration.** `FINANCE_APP_DB_PASSWORD`, `FINANCE_IMPORTER_DB_PASSWORD`, and `FINANCE_METABASE_DB_PASSWORD` must be added to `.env` (see `.env.example`) — the `migrate` service aborts with a pointer to `.env.example` rather than creating a login role with a blank password. Copy the three keys in and run `docker compose up`; the roles and grants are applied to existing databases automatically. Metabase users must additionally re-point the Finances connection at `finance_metabase` once in the admin UI, since Metabase stores analytics connections in its own metadata database rather than in environment variables ([Issue #130](https://github.com/aellington89/finance-stack/issues/130)).
+
 ### Added
 
 - Scheduled database backups: a default-on `pg-backup` Compose service runs `pg_dump` (custom format) of the `Finances` and `metabase` databases into `./backups/` on an interval (default daily) with retention pruning, plus `scripts/backup.sh` / `scripts/restore.sh` (one-command restore into a clean DB, guarded against clobbering production DBs without `--force`) and a weekly `backup-smoke` CI workflow that seeds a known dataset, dumps it, restores it, and asserts a known row count to catch silent backup corruption. Documented in the new [docs/backups.md](docs/backups.md); tunable via `BACKUP_DBS` / `BACKUP_RETENTION_DAYS` / `BACKUP_INTERVAL_SECONDS` (see `.env.example`) ([Issue #122](https://github.com/aellington89/finance-stack/issues/122)).
@@ -14,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Postgres surface-area lockdown: the Postgres (`5433`) and Metabase (`3000`) host ports are now bound to `127.0.0.1` instead of `0.0.0.0`, and the three long-running services no longer connect as the `postgres` superuser. Each authenticates as its own least-privilege role — `finance_app` (full DML on the core tables, **`SELECT`-only on `users`**, no DDL), `finance_importer` (append-only on `transactions` plus lookup reads, no `UPDATE`/`DELETE`), and `finance_metabase` (`SELECT` on the three views, no base-table access at all). None can create, alter, drop, or truncate a table, create roles or databases, or reach the `drizzle` migration ledger; tables stay owned by `POSTGRES_USER`. The superuser is retained only for the maintenance jobs that need DDL or cluster-wide reads (`migrate`, `init-script`, `pg-backup`). Roles and grants are created and re-applied idempotently by the `migrate` service on every `docker compose up` (`init-db/roles/`), so existing volumes are upgraded with no manual SQL, and the grant files revoke before granting so a hand-widened privilege converges back. A new CI "role privilege gate" (`scripts/verify-db-roles.sh`) asserts the full matrix against the catalog and then connects as each role to confirm permitted statements succeed and forbidden ones are refused. Documented in [docs/database.md](docs/database.md#roles--privileges) ([Issue #130](https://github.com/aellington89/finance-stack/issues/130)).
 - All application pages and every server action now reject unauthenticated requests, enforced in three layers: the Next 16 proxy (`app/proxy.ts`) redirects to `/login`, the `(app)` layout re-verifies the session server-side, and `requireActionUser()` gates each of the 18 server actions individually. Only the landing page, `/login`, `/api/auth/*`, and `/api/health` (Docker healthcheck + release smoke test) remain public ([Issue #120](https://github.com/aellington89/finance-stack/issues/120)).
 
 ## [0.1.5] - 2026-07-10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ is tolerated by the release-notes generator but is not preferred — use the
 
 ## CI gates
 
-CI runs on every push to `master`/`test` and on all PRs. There are three gates
-that can fail a build before lint and tests even run; all three are fast to
+CI runs on every push to `master`/`test` and on all PRs. There are four gates
+that can fail a build before lint and tests even run; all four are fast to
 satisfy locally:
 
 ### Schema-drift gate
@@ -69,6 +69,23 @@ table/id/name tuples) doesn't match a row in `init-db/seeds/shared-lookups.sql`.
 ```sh
 cd app && npm run check:seed-references
 ```
+
+### Role privilege gate
+
+Fails if the database service roles don't hold exactly the privileges
+`init-db/roles/02-grants.sql` is meant to establish — too few or too many. Most
+often tripped by a migration that adds a table or view the narrow
+`finance_importer` / `finance_metabase` roles need, since those grants are
+enumerated by hand (`finance_app` is covered automatically).
+
+**Fix:** update `init-db/roles/02-grants.sql`, then verify against a running
+stack:
+
+```sh
+docker compose run --rm --entrypoint bash migrate /scripts/verify-db-roles.sh Finances_Test
+```
+
+See [Roles & Privileges](docs/database.md#roles--privileges).
 
 ### Changelog gate
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A containerized personal finance data warehouse for aggregating, storing, and vi
 
 | Service | Description | Local Port |
 |---|---|---|
-| PostgreSQL 18 | Primary database | 5433 |
+| PostgreSQL 18 | Primary database | 5433 (loopback only) |
 | Next.js 16 | Custom finance application | 3001 |
 | importer | File ingestion (polls `imports/` subfolders) | — |
-| Metabase | BI dashboards and analytics (`--profile bi`) | 3000 |
+| Metabase | BI dashboards and analytics (`--profile bi`) | 3000 (loopback only) |
 
 ## Security
 
@@ -21,6 +21,8 @@ npm run auth:create-user -- <username>
 ```
 
 Sign in at http://localhost:3001/login and sign out from the sidebar footer. See [docs/auth.md](docs/auth.md) for the full model, the `AUTH_SECRET` requirement, and password resets.
+
+At the data tier, Postgres and Metabase publish their host ports on **loopback only**, and each service connects as its own **least-privilege role** rather than the `postgres` superuser: the app has no DDL and is read-only on `users`, the importer can only append transactions, and Metabase sees the three views and no base tables. See [docs/database.md](docs/database.md#roles--privileges) for the grant matrix and how to verify it.
 
 Authentication alone does not make the app safe for the public internet: transport encryption, rate limiting, and deployment hardening are still tracked in [#100](https://github.com/aellington89/finance-stack/issues/100) (see [#130](https://github.com/aellington89/finance-stack/issues/130), [#181](https://github.com/aellington89/finance-stack/issues/181), [#182](https://github.com/aellington89/finance-stack/issues/182)). Keep it on a trusted network — localhost, a VPN, Tailscale, or similar — until those land.
 
@@ -37,11 +39,13 @@ Authentication alone does not make the app safe for the public internet: transpo
 cp .env.example .env
 ```
 
-Edit `.env` and replace the `changeme` placeholder passwords with your own values. Generate a real `AUTH_SECRET` (signs the session cookies):
+Edit `.env` and replace **every** `changeme` placeholder with your own value — including the three `FINANCE_*_DB_PASSWORD` service-role passwords, which are required (the migrate service aborts rather than create a login role with a blank password). Keep them URL-safe, since they go into connection strings. Generate a real `AUTH_SECRET` (signs the session cookies):
 
 ```bash
 openssl rand -base64 33
 ```
+
+> **Upgrading an existing stack?** `FINANCE_APP_DB_PASSWORD`, `FINANCE_IMPORTER_DB_PASSWORD`, and `FINANCE_METABASE_DB_PASSWORD` are new. Copy them from `.env.example` into your `.env`, then `docker compose up` — the migrate service creates the roles and applies their grants to your existing databases. No manual SQL, no data migration. If you use Metabase, re-point its Finances connection at `finance_metabase` ([docs/database.md](docs/database.md#pointing-metabase-at-finance_metabase)).
 
 ### 2. Start the stack
 
@@ -103,8 +107,8 @@ The app starts on http://localhost:3001 with Turbopack for fast refresh.
 ### 5. Access the services
 
 - **Finance App:** http://localhost:3001
-- **Metabase:** http://localhost:3000 (requires `--profile bi`)
-- **PostgreSQL:** `localhost:5433` (user: `postgres`, database: `Finances`)
+- **Metabase:** http://localhost:3000 (requires `--profile bi`; loopback only)
+- **PostgreSQL:** `localhost:5433` (database: `Finances`) — loopback only, so use `localhost`, not the host's LAN address. Connect as `postgres` for admin work; the services use their own restricted roles ([grant matrix](docs/database.md#roles--privileges)).
 
 ## Stopping the Stack
 

--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -5,6 +5,14 @@
 # Defaults to the test database for safe local development.
 # Local development (host machine): use localhost:5433
 # Docker container (appnet network): use postgres:5432
+#
+# Local dev connects as the superuser on purpose: drizzle-kit needs DDL, and the
+# integration suite calls setval() and writes the users table — neither of which
+# the finance_app role may do (Issue #130). The containerized app connects as
+# finance_app instead (see docker-compose.yml). To exercise least privilege
+# locally, swap in:
+#   postgresql://finance_app:<FINANCE_APP_DB_PASSWORD>@localhost:5433/Finances_Test
+# Postgres now listens on 127.0.0.1 only, so localhost:5433 still works here.
 DATABASE_URL=postgresql://postgres:changeme@localhost:5433/Finances_Test
 
 # Secret used by Auth.js to sign/encrypt session JWTs (Issue #120).

--- a/app/scripts/migrate-and-seed.sh
+++ b/app/scripts/migrate-and-seed.sh
@@ -5,8 +5,16 @@
 # Runs in the `migrate` Compose service after postgres becomes
 # healthy. Idempotent: safe to re-run on every `docker compose up`.
 #
-# For each target database it:
+# It first creates the least-privilege service roles from /roles/ (mounted from
+# init-db/roles) — those are cluster-global, so once per run. Then, for each
+# target database it:
 #   1. Applies any pending Drizzle migrations (drizzle-kit migrate).
+#   2. Applies that database's service-role grants (/roles/02-grants.sql).
+#
+# Roles and grants live here rather than in init-db/01-create-databases.sh for
+# two reasons (issue #130): that script only runs on an empty data directory, so
+# an existing Postgres volume would never gain the roles; and a GRANT names
+# tables, so it can only run after step 1 has created them.
 #
 # Then it applies seed files from /seeds/ (mounted from init-db/seeds):
 #   - Finances:      shared-lookups.sql, but ONLY if the DB has no
@@ -17,11 +25,20 @@
 #
 # Required env vars (set by docker-compose.yml):
 #   PGHOST, PGPORT, PGUSER, PGPASSWORD, FINANCE_APP_DB
+#   FINANCE_APP_DB_PASSWORD, FINANCE_IMPORTER_DB_PASSWORD,
+#   FINANCE_METABASE_DB_PASSWORD  (the three service-role passwords, #130)
 # ------------------------------------------------------------
 set -euo pipefail
 
 FINANCE_APP_DB="${FINANCE_APP_DB:-Finances}"
 TEST_DB="Finances_Test"
+
+# Fail fast and loudly on a missing role password. Compose substitutes an unset
+# variable with the empty string rather than leaving it unset, so without these
+# guards a stale .env would silently create login roles with blank passwords.
+: "${FINANCE_APP_DB_PASSWORD:?must be set — copy the new keys from .env.example into .env (issue #130)}"
+: "${FINANCE_IMPORTER_DB_PASSWORD:?must be set — copy the new keys from .env.example into .env (issue #130)}"
+: "${FINANCE_METABASE_DB_PASSWORD:?must be set — copy the new keys from .env.example into .env (issue #130)}"
 
 # Baseline journal `when` — the value drizzle-kit stores as created_at when it
 # applies 0000_baseline itself. Derived from the journal so it tracks the file
@@ -59,9 +76,27 @@ END
 SQL
 }
 
+# Grants the least-privilege service roles their per-database privileges. Must
+# run after run_migrate for the same database: GRANT statements name tables, so
+# they fail on a database whose schema has not been created yet.
+apply_grants() {
+    local db="$1"
+    echo ">>> Applying service-role grants to ${db}..."
+    psql -v ON_ERROR_STOP=1 -d "${db}" -v OWNER="${PGUSER}" -f /roles/02-grants.sql
+}
+
+# Roles are cluster-global, so create them once, before the per-database loop.
+echo ">>> Creating least-privilege service roles..."
+psql -v ON_ERROR_STOP=1 -d postgres \
+    -v app_password="${FINANCE_APP_DB_PASSWORD}" \
+    -v importer_password="${FINANCE_IMPORTER_DB_PASSWORD}" \
+    -v metabase_password="${FINANCE_METABASE_DB_PASSWORD}" \
+    -f /roles/01-create-roles.sql
+
 for db in "${FINANCE_APP_DB}" "${TEST_DB}"; do
     heal_adopted_baseline "${db}"
     run_migrate "${db}"
+    apply_grants "${db}"
 done
 
 # --- Finances: additive lookup seed, only when the DB is empty.
@@ -86,4 +121,4 @@ psql -v ON_ERROR_STOP=1 -d "${TEST_DB}" -f /seeds/finances-test-mock-data.sql
 echo ">>> Rebuilding ${TEST_DB} account_balance_history..."
 psql -v ON_ERROR_STOP=1 -d "${TEST_DB}" -f /seeds/rebuild-balance-history.sql
 
-echo ">>> Migrations and seeds complete."
+echo ">>> Migrations, roles, and seeds complete."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,11 @@ services:
       MB_DB_PASS: ${MB_DB_PASS}
       MB_DB_DBNAME: ${MB_DB_DBNAME}
     ports:
-      - "5433:5432"              # Exposed on 5433 to avoid conflicts with a local Postgres on the default port
+      # 5433 avoids conflicts with a local Postgres on the default port. Bound to
+      # loopback (#130): reachable from this host only, refused on the LAN. Local
+      # clients (psql, DBeaver, `npm run dev`) keep using localhost:5433; the
+      # services reach the DB over appnet, which is unaffected by this.
+      - "127.0.0.1:5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql  # PG18 moved PGDATA to /var/lib/postgresql/18/docker; mount the parent
       - ./init-db:/docker-entrypoint-initdb.d:ro  # Runs once on first start (empty data dir) to create DBs and roles
@@ -66,11 +70,19 @@ services:
     environment:
       PGHOST: postgres
       PGPORT: 5432
-      PGUSER: ${POSTGRES_USER}
+      PGUSER: ${POSTGRES_USER}          # Superuser: this job applies DDL and creates roles
       PGPASSWORD: ${POSTGRES_PASSWORD}
       FINANCE_APP_DB: ${FINANCE_APP_DB:-Finances}
+      # Passwords for the least-privilege service roles this job creates (#130).
+      # Deliberately no defaults — migrate-and-seed.sh aborts if any is empty
+      # rather than creating a login role with a blank password.
+      FINANCE_APP_DB_PASSWORD: ${FINANCE_APP_DB_PASSWORD}
+      FINANCE_IMPORTER_DB_PASSWORD: ${FINANCE_IMPORTER_DB_PASSWORD}
+      FINANCE_METABASE_DB_PASSWORD: ${FINANCE_METABASE_DB_PASSWORD}
     volumes:
       - ./init-db/seeds:/seeds:ro        # Seed SQL files consumed by migrate-and-seed.sh
+      - ./init-db/roles:/roles:ro        # Role creation + grant SQL (#130)
+      - ./scripts:/scripts:ro            # For the on-demand role check — see scripts/verify-db-roles.sh
     networks:
       - appnet
     logging: *default-logging
@@ -145,7 +157,9 @@ services:
     ports:
       - "3001:3001"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${FINANCE_APP_DB:-Finances}
+      # Connects as finance_app, not the superuser (#130): full DML on the core
+      # tables, SELECT-only on users, and no DDL. See docs/database.md.
+      DATABASE_URL: postgresql://finance_app:${FINANCE_APP_DB_PASSWORD}@postgres:5432/${FINANCE_APP_DB:-Finances}
       AUTH_SECRET: ${AUTH_SECRET}       # Signs/encrypts Auth.js session JWTs — see .env.example
     depends_on:
       migrate:
@@ -180,7 +194,10 @@ services:
       migrate:
         condition: service_completed_successfully
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${FINANCE_APP_DB:-Finances}
+      # Connects as finance_importer (#130): append-only on transactions plus
+      # SELECT on the lookup tables it resolves FKs against. It cannot UPDATE or
+      # DELETE anything, so a bad parser can only ever add rows.
+      DATABASE_URL: postgresql://finance_importer:${FINANCE_IMPORTER_DB_PASSWORD}@postgres:5432/${FINANCE_APP_DB:-Finances}
       POLL_INTERVAL: 60
     volumes:
       - ./imports:/input                      # Host drop folder — each subdirectory is an import type
@@ -259,13 +276,19 @@ services:
 
   # Metabase BI tool for dashboards and ad-hoc analytics against the Finances database.
   # Stores its own internal metadata (questions, dashboards, users) in a separate metabase DB.
+  #
+  # The MB_DB_* vars below configure only that internal metadata DB (owned by the
+  # non-superuser MB_DB_USER role). Metabase's *analytics* connection to Finances is
+  # stored inside its own metadata DB, not in env, so it cannot be set here: point it
+  # at the finance_metabase role (views only, #130) once in the admin UI — see the
+  # "Roles & privileges" section of docs/database.md.
   metabase:
     image: metabase/metabase:v0.58.8
     container_name: metabase
     profiles: ["bi"]                   # Not started by default; run with --profile bi
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"    # Loopback only (#130) — Metabase has no auth in front of it on the LAN
     environment:
       MB_DB_TYPE: postgres
       MB_DB_DBNAME: ${MB_DB_DBNAME}         # Metabase's internal state DB — separate from the Finances DB

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -35,6 +35,8 @@ DATABASE_URL=postgresql://postgres:<password>@localhost:5433/Finances \
   npm run auth:create-user -- <username>
 ```
 
+> **This must connect as `postgres`, not `finance_app`.** The `users` table is deliberately read-only to the application role (Issue #130), so that an app-level compromise cannot mint or alter an account. Running the CLI as `finance_app` fails with `permission denied for table users` — that is the guard working, not a bug. See [Roles & Privileges](database.md#roles--privileges).
+
 For non-interactive use, set `CREATE_USER_PASSWORD` instead of the prompt.
 
 ## Configuration

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -75,6 +75,18 @@ docker compose exec pg-backup /scripts/restore.sh --force \
 For a from-scratch rebuild (lost volume), bring the stack up so the databases
 are created and migrated, then run the restore above.
 
+> **Restoring into a different cluster: create the roles first.** Dumps are taken
+> as the superuser, so they carry the `GRANT` statements for `finance_app`,
+> `finance_importer`, and `finance_metabase`, and `restore.sh` uses
+> `pg_restore --no-owner`, which still applies privileges. Restoring into a
+> cluster where those roles do not exist produces `role "finance_app" does not
+> exist` errors on those statements. Bringing the stack up first (which runs the
+> migrate service, creating the roles) avoids this; a later `docker compose up`
+> re-applies the grants either way, since
+> [`02-grants.sql`](../init-db/roles/02-grants.sql) converges. Restores into the
+> same cluster — the normal case, including the `--force` recovery above — are
+> unaffected.
+
 ## Verification (CI)
 
 `.github/workflows/backup-smoke.yml` runs weekly (and on PRs touching the backup

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,6 +1,6 @@
 # Database
 
-Covers the schema, views, balance-history table, first-launch initialization, and the test database.
+Covers the schema, views, balance-history table, first-launch initialization, the service roles and their privileges, and the test database.
 
 ## Schema
 
@@ -40,12 +40,80 @@ On the first `docker compose up` (empty Postgres data volume), [`init-db/01-crea
 
 Schema and seeding then come from the `migrate` Compose service, which runs after postgres is healthy. The migrate service:
 
-1. Applies pending Drizzle migrations from [`app/drizzle/migrations/`](../app/drizzle/migrations/) to both `Finances` and `Finances_Test`.
+1. Creates the least-privilege service roles, then applies pending Drizzle migrations from [`app/drizzle/migrations/`](../app/drizzle/migrations/) to both `Finances` and `Finances_Test` and grants each role its privileges — see [Roles & Privileges](#roles--privileges).
 2. Seeds the two **shared lookup tables** (`account_type_categories`, `transaction_types`) into both databases so they start in sync. The Finances side uses `ON CONFLICT DO NOTHING` and is additionally guarded by a pre-flight row-count check — **existing Finances user data is never overwritten**, even on a manual re-run.
 3. Seeds `Finances_Test` with mock data: all 19 `account_types`, all 27 `transaction_categories`, 8 accounts, and ~400 transactions spanning the past 12 months relative to `CURRENT_DATE` at seed time.
 4. Rebuilds `Finances_Test.account_balance_history` so balances are up-to-date as of today.
 
 `finance-app` and `importer` wait on `migrate: service_completed_successfully` before starting. After the migrate service exits, `Finances` contains only the shared lookups and is ready for the user (or the importer) to populate via normal application use. `Finances_Test` contains a full year of mock activity usable by integration tests and for UI development.
+
+## Roles & Privileges
+
+The long-running services do **not** connect as the `postgres` superuser (Issue #130). Each authenticates as its own login role, scoped to what it actually does:
+
+| Role | Used by | Privileges |
+|---|---|---|
+| `finance_app` | `finance-app` | `SELECT`/`INSERT`/`UPDATE`/`DELETE` on every table **except `users`, which is `SELECT`-only**; `SELECT` on the views; `USAGE` on the sequences |
+| `finance_importer` | `importer` | `SELECT` + `INSERT` on `transactions`; `SELECT` on `accounts`, `transaction_categories`, `transaction_types`. No `UPDATE`, no `DELETE` |
+| `finance_metabase` | Metabase's Finances connection | `SELECT` on the three views. **No privilege on any base table** |
+
+None of them is a superuser, none can create databases or roles, and none has `CREATE` on schema `public` — so no service can add, alter, drop, or truncate a table, and none can reach the `drizzle` migration ledger. Tables stay owned by `POSTGRES_USER`, which is what makes that true.
+
+The superuser is still used, deliberately, by the jobs that need DDL or cluster-wide reads: `migrate`, `init-script`, and `pg-backup`. Those are maintenance jobs with no network-facing surface.
+
+Two details worth knowing before you change any of this:
+
+- **`finance_metabase` works without base-table access** because the three views are created without `security_invoker`, so they execute with the view *owner's* rights. `SELECT` on the view is sufficient, and the underlying tables stay invisible in Metabase's data browser. Add `security_invoker` to a view and this role stops being able to read it.
+- **`finance_app` is granted broadly and then revoked** (`GRANT … ON ALL TABLES`, then `REVOKE … ON users`) plus `ALTER DEFAULT PRIVILEGES`, so a table added by a future migration is covered automatically. The two narrow roles are enumerated instead — if a migration adds a table or view they need, [`init-db/roles/02-grants.sql`](../init-db/roles/02-grants.sql) must be updated by hand.
+
+### How the roles are applied
+
+Roles and grants are applied by the **`migrate` service** on every `docker compose up`, not by `init-db/01-create-databases.sh`. Two reasons: that script only runs on an empty data directory, so an existing Postgres volume would never gain the roles; and a `GRANT` names tables, so it can only run after migrations have created them.
+
+| File | Purpose |
+|---|---|
+| [`init-db/roles/01-create-roles.sql`](../init-db/roles/01-create-roles.sql) | Creates the three login roles (cluster-global, so it runs once per migrate run) |
+| [`init-db/roles/02-grants.sql`](../init-db/roles/02-grants.sql) | Applies the matrix above to one database; run against `Finances` and `Finances_Test` |
+| [`init-db/roles/assert-grants.sql`](../init-db/roles/assert-grants.sql) | Asserts the matrix against the catalog — the CI grant gate |
+
+`02-grants.sql` **revokes before it grants**, inside a transaction, so it converges: a privilege widened by hand is removed on the next `up`, and there is no window in which a running app has no access.
+
+### Verifying the roles
+
+[`scripts/verify-db-roles.sh`](../scripts/verify-db-roles.sh) checks both layers — the catalog matrix, then a behavioural smoke that connects as each role and asserts that permitted statements succeed and forbidden ones are refused with `SQLSTATE 42501`. Writes are rolled back, so it is safe against a populated database:
+
+```bash
+docker compose run --rm --entrypoint bash migrate /scripts/verify-db-roles.sh Finances
+```
+
+The `migrate` service already carries every variable the script needs, so no `-e` flags are required. CI runs the same script against `Finances_Test` on every PR.
+
+### Rotating a role password
+
+Edit the relevant `FINANCE_*_DB_PASSWORD` in `.env`, then re-run the migrate service — `01-create-roles.sql` issues an unconditional `ALTER ROLE … PASSWORD`, so the new value takes effect with no manual SQL:
+
+```bash
+docker compose run --rm migrate
+docker compose up -d --force-recreate finance-app importer
+```
+
+Passwords are interpolated into URL-form connection strings, so keep them URL-safe or percent-encode them.
+
+> **This works for the three `FINANCE_*_DB_PASSWORD` values only.** `POSTGRES_PASSWORD` and `MB_DB_PASS` are *not* rotatable from `.env`: the Postgres image applies `POSTGRES_PASSWORD` solely via `initdb` on an empty data directory, and the Metabase role is created by `init-db/01-create-databases.sh`, which the entrypoint skips once `PGDATA` is initialized. Editing either value on an existing volume leaves the stored password unchanged and breaks every service that authenticates with the new one (loudly — `migrate` fails on `password authentication failed`). To change them, alter the role first, then update `.env`:
+>
+> ```bash
+> docker compose exec postgres psql -U postgres    # then: \password postgres   (or \password metabase_user)
+> # update POSTGRES_PASSWORD / MB_DB_PASS in .env to the same value
+> docker compose up -d --force-recreate
+> ```
+>
+> The service roles avoid this trap because `01-create-roles.sql` re-issues `ALTER ROLE … PASSWORD` on every migrate run.
+
+### Pointing Metabase at `finance_metabase`
+
+Metabase stores its analytics connections in its own metadata database, not in environment variables, so this one role cannot be wired through `docker-compose.yml` — it is a one-time manual step. In Metabase, go to **Settings → Admin → Databases → your Finances database**, change the username to `finance_metabase` and the password to `FINANCE_METABASE_DB_PASSWORD`, and save. Existing questions built on the three views keep working; anything built directly on a base table will stop, which is the intended outcome.
+
+`MB_DB_USER` is unrelated and unchanged — it owns Metabase's *internal* metadata database and was never the superuser.
 
 ## Test Database
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -196,6 +196,10 @@ finance-stack/
 ├── .vscode/extensions.json              # Recommended VS Code extensions for this project
 ├── init-db/
 │   ├── 01-create-databases.sh            # First-run DB + Metabase role creation only (auto-runs on empty data dir)
+│   ├── roles/                            # Least-privilege service roles (#130), applied by the `migrate` service
+│   │   ├── 01-create-roles.sql           # finance_app / finance_importer / finance_metabase (cluster-global)
+│   │   ├── 02-grants.sql                 # Per-database grant matrix; revokes then grants, so it converges
+│   │   └── assert-grants.sql             # Catalog assertions for the matrix — the CI grant gate
 │   └── seeds/                            # Applied by the `migrate` Compose service after migrations
 │       ├── shared-lookups.sql            # account_type_categories + transaction_types (both DBs)
 │       ├── finances-test-mock-data.sql   # account_types, transaction_categories, accounts, ~400 txns (Finances_Test only)
@@ -203,5 +207,6 @@ finance-stack/
 └── scripts/
     ├── update-account-balance-history.sql   # Balance history rebuild script (manual / --profile init)
     ├── backup.sh                            # Scheduled pg_dump with retention pruning (pg-backup service)
-    └── restore.sh                           # Restore a dump into a clean database (#122)
+    ├── restore.sh                           # Restore a dump into a clean database (#122)
+    └── verify-db-roles.sh                   # Grant matrix + behavioural privilege check per role (#130)
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,16 @@
 # Testing
 
-Covers running unit and integration tests and the static lookup-table fixtures.
+Covers running unit and integration tests, the static lookup-table fixtures, and the database role gate.
+
+## Database Role Gate
+
+CI verifies the least-privilege service roles (Issue #130) on every PR via [`scripts/verify-db-roles.sh`](../scripts/verify-db-roles.sh): it applies the real grant files to `Finances_Test`, asserts the whole grant matrix against the catalog, and then connects as each role to confirm that permitted statements succeed and forbidden ones are refused with `SQLSTATE 42501`. Run it yourself with:
+
+```bash
+docker compose run --rm --entrypoint bash migrate /scripts/verify-db-roles.sh Finances
+```
+
+**The integration suite still connects as `postgres`, and should stay that way.** Two of its behaviours are ones `finance_app` is deliberately not allowed: [`vitest-setup.ts`](../app/tests/integration/vitest-setup.ts) calls `setval()` on the lookup sequences (needs `UPDATE` on the sequence; the role has only `USAGE`), and [`auth/verify-credentials.test.ts`](../app/tests/integration/auth/verify-credentials.test.ts) inserts into `users` (read-only to the app role). Pointing the suite at `finance_app` would fail for exactly the reasons the grants exist — role coverage belongs in the gate above, not in the suite.
 
 ## Static Lookup Tables in Integration Tests
 

--- a/init-db/roles/01-create-roles.sql
+++ b/init-db/roles/01-create-roles.sql
@@ -1,0 +1,56 @@
+-- ==============================================
+-- Least-privilege service roles (Issue #130).
+--
+-- Creates the three login roles the long-running services authenticate as,
+-- replacing the shared `postgres` superuser:
+--   finance_app       — the Next.js app (DML on core tables, SELECT on users)
+--   finance_importer  — the file importer (INSERT into transactions + lookups)
+--   finance_metabase  — Metabase's Finances connection (SELECT on views only)
+--
+-- Roles are cluster-global, so this file runs ONCE per migrate run against the
+-- maintenance database. Per-database privileges live in 02-grants.sql.
+--
+-- Applied by the `migrate` Compose service (app/scripts/migrate-and-seed.sh),
+-- not by init-db/01-create-databases.sh: that script only runs on an empty data
+-- directory, so an existing Postgres volume would never gain the roles. The
+-- migrate service runs idempotently on every `docker compose up`.
+--
+-- Required psql variables (passed with -v by the caller):
+--   app_password, importer_password, metabase_password
+--
+-- Passwords are interpolated as psql variables rather than shell-expanded into
+-- the SQL text, and quoted by format(%L) so a password containing a quote can
+-- neither break the statement nor inject SQL. Note that psql does NOT expand
+-- :variables inside dollar-quoted strings, which is why this uses \gexec rather
+-- than a DO $$ ... $$ block (the pattern 01-create-databases.sh already uses).
+--
+-- Each role gets two statements: a guarded CREATE, then an unconditional ALTER.
+-- The ALTER re-asserts the attribute set and syncs the password, so rotating a
+-- password in .env takes effect on the next `up` with no manual SQL.
+-- ==============================================
+
+\set ON_ERROR_STOP on
+
+-- ── finance_app ───────────────────────────────────────────────────────────
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', 'finance_app', :'app_password')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'finance_app')\gexec
+
+SELECT format(
+    'ALTER ROLE %I WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION'
+    ' NOBYPASSRLS PASSWORD %L', 'finance_app', :'app_password')\gexec
+
+-- ── finance_importer ──────────────────────────────────────────────────────
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', 'finance_importer', :'importer_password')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'finance_importer')\gexec
+
+SELECT format(
+    'ALTER ROLE %I WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION'
+    ' NOBYPASSRLS PASSWORD %L', 'finance_importer', :'importer_password')\gexec
+
+-- ── finance_metabase ──────────────────────────────────────────────────────
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', 'finance_metabase', :'metabase_password')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'finance_metabase')\gexec
+
+SELECT format(
+    'ALTER ROLE %I WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION'
+    ' NOBYPASSRLS PASSWORD %L', 'finance_metabase', :'metabase_password')\gexec

--- a/init-db/roles/02-grants.sql
+++ b/init-db/roles/02-grants.sql
@@ -1,0 +1,116 @@
+-- ==============================================
+-- Per-database privileges for the least-privilege service roles (Issue #130).
+--
+-- Runs once per target database (Finances, Finances_Test) on every migrate run,
+-- AFTER drizzle-kit has applied migrations — grants can only reference tables
+-- that already exist, which is why this lives in the migrate service rather than
+-- in init-db/01-create-databases.sh. Roles themselves come from 01-create-roles.sql.
+--
+-- Contains no secrets, so CI applies this exact file to Finances_Test and then
+-- gates on assert-grants.sql. One authority, exercised twice.
+--
+-- Required psql variables:
+--   OWNER    the role that owns the tables (POSTGRES_USER) — the role whose
+--            future CREATEs the ALTER DEFAULT PRIVILEGES statements attach to.
+--   DBNAME   set automatically by psql from the -d connection.
+--
+-- The grant matrix (see docs/database.md):
+--
+--   finance_app       DML on every public table except users (SELECT only),
+--                     SELECT on the views, USAGE on the sequences.
+--   finance_importer  SELECT+INSERT on transactions, SELECT on the three lookup
+--                     tables it resolves FKs against, and nothing else.
+--   finance_metabase  SELECT on the three views. No base-table access at all.
+--
+-- Table ownership stays with OWNER, so no service role can ALTER or DROP the
+-- schema, TRUNCATE a table, or touch the `drizzle` migration ledger.
+-- ==============================================
+
+\set ON_ERROR_STOP on
+
+-- Atomic: the revoke/re-grant below would otherwise leave a window in which a
+-- running finance-app has no privileges and starts erroring mid-request.
+BEGIN;
+
+-- ── Baseline: nothing is implicit ─────────────────────────────────────────
+-- PUBLIC (i.e. every role, present and future) loses CONNECT/TEMP on the
+-- database and CREATE on the schema. Both are already the default on
+-- postgres:18.0 (PG15+ removed the public CREATE grant), asserted here so a
+-- restored dump or a hand-run GRANT cannot silently widen the surface.
+REVOKE ALL ON DATABASE :"DBNAME" FROM PUBLIC;
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+
+-- Converge: strip every privilege the three roles currently hold in this
+-- database before re-granting, so this file is the single authority. Without
+-- this, narrowing a grant here would leave the old wider grant in place.
+REVOKE ALL ON DATABASE :"DBNAME"          FROM finance_app, finance_importer, finance_metabase;
+REVOKE ALL ON SCHEMA public               FROM finance_app, finance_importer, finance_metabase;
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM finance_app, finance_importer, finance_metabase;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM finance_app, finance_importer, finance_metabase;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE :"OWNER" IN SCHEMA public
+    REVOKE ALL ON TABLES FROM finance_app, finance_importer, finance_metabase;
+ALTER DEFAULT PRIVILEGES FOR ROLE :"OWNER" IN SCHEMA public
+    REVOKE ALL ON SEQUENCES FROM finance_app, finance_importer, finance_metabase;
+
+-- ── finance_app — the Next.js application ─────────────────────────────────
+-- Granted broadly ("all tables, minus explicit revokes") rather than as an
+-- enumerated list on purpose: broad DML *is* this role's charter (the settings
+-- CRUD in lib/actions/categories.ts writes every lookup table), and an
+-- enumerated list would silently break the app the first time a migration adds
+-- a table. The single REVOKE below keeps the one exception auditable.
+GRANT CONNECT ON DATABASE :"DBNAME" TO finance_app;
+GRANT USAGE ON SCHEMA public TO finance_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO finance_app;
+
+-- users is read-only to the app: credentials are verified here, but accounts are
+-- only ever created or reset by `npm run auth:create-user`, which connects as
+-- POSTGRES_USER. So an app-level injection or RCE cannot mint an admin user.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON users FROM finance_app;
+
+-- accounts.account_id and transactions.transaction_id are `serial`, so INSERT
+-- needs USAGE on their sequences. USAGE+SELECT permits nextval/currval but not
+-- setval — the lookup tables' GENERATED ALWAYS AS IDENTITY sequences need no
+-- grant at all.
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO finance_app;
+
+-- Cover tables and sequences created by future migrations. Default privileges
+-- attach at CREATE time, so they only help from the *next* migrate run onward —
+-- the GRANT ... ON ALL statements above are what cover a fresh database.
+ALTER DEFAULT PRIVILEGES FOR ROLE :"OWNER" IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO finance_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE :"OWNER" IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO finance_app;
+
+-- ── finance_importer — the file importer ──────────────────────────────────
+-- Enumerated deliberately: narrowness is the whole point of this role. It
+-- appends transactions and resolves FKs by name (importer/poll.py
+-- load_lookup_maps + parsers/*.process). It cannot UPDATE or DELETE anything,
+-- so a bad parser can only ever add rows — never rewrite history.
+GRANT CONNECT ON DATABASE :"DBNAME" TO finance_importer;
+GRANT USAGE ON SCHEMA public TO finance_importer;
+GRANT SELECT, INSERT ON transactions TO finance_importer;
+GRANT SELECT ON accounts, transaction_categories, transaction_types TO finance_importer;
+
+-- Resolved rather than hardcoded, matching init-db/seeds/shared-lookups.sql.
+SELECT format('GRANT USAGE, SELECT ON SEQUENCE %s TO finance_importer',
+              pg_get_serial_sequence('transactions', 'transaction_id'))\gexec
+
+-- ── finance_metabase — Metabase's Finances connection ─────────────────────
+-- Views only, and no base-table access whatsoever. This works because the three
+-- views are created without `security_invoker` (see 0000_baseline.sql), so they
+-- execute with the view owner's rights: SELECT on the view is sufficient and the
+-- underlying tables stay invisible in Metabase's data browser.
+--
+-- Note this role is NOT wired through docker-compose.yml — Metabase stores its
+-- analytics connections in its own metadata DB, so the credentials are entered
+-- once in the Metabase admin UI (see docs/database.md). MB_DB_USER remains the
+-- separate role for Metabase's internal metadata database.
+--
+-- A new view added by a future migration must be added here explicitly.
+GRANT CONNECT ON DATABASE :"DBNAME" TO finance_metabase;
+GRANT USAGE ON SCHEMA public TO finance_metabase;
+GRANT SELECT ON v_transactions_full, v_account_balances_current, v_daily_totals
+    TO finance_metabase;
+
+COMMIT;

--- a/init-db/roles/assert-grants.sql
+++ b/init-db/roles/assert-grants.sql
@@ -1,0 +1,176 @@
+-- ==============================================
+-- Grant-matrix gate (Issue #130).
+--
+-- Asserts that the privileges 02-grants.sql is supposed to have established are
+-- exactly what the catalog reports — positively (each role CAN do its job) and
+-- negatively (each role CANNOT do anything else). Raises an exception listing
+-- every violation, so one run reports all problems rather than the first.
+--
+-- Run against the same database 02-grants.sql was applied to:
+--   psql -v ON_ERROR_STOP=1 -d Finances_Test -f init-db/roles/assert-grants.sql
+--
+-- Wired into CI as the "grant matrix gate" (.github/workflows/ci.yml). Catalog
+-- assertions alone cannot prove that SELECT-on-a-view-without-base-table-access
+-- actually works at query time, so CI pairs this with a behavioural smoke that
+-- connects as each role. Keep both in sync with docs/database.md.
+-- ==============================================
+
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE
+    failures text[] := '{}';
+    db       text   := current_database();
+    txn_seq  text   := pg_get_serial_sequence('transactions', 'transaction_id');
+    acct_seq text   := pg_get_serial_sequence('accounts', 'account_id');
+    r        record;
+    t        text;
+BEGIN
+    -- ── Roles exist with the right attributes ─────────────────────────────
+    FOREACH t IN ARRAY ARRAY['finance_app', 'finance_importer', 'finance_metabase']
+    LOOP
+        SELECT * INTO r FROM pg_roles WHERE rolname = t;
+        IF NOT FOUND THEN
+            failures := failures || format('role %s does not exist', t);
+            CONTINUE;
+        END IF;
+        IF NOT r.rolcanlogin  THEN failures := failures || format('%s cannot LOGIN', t); END IF;
+        IF r.rolsuper         THEN failures := failures || format('%s is SUPERUSER', t); END IF;
+        IF r.rolcreatedb      THEN failures := failures || format('%s has CREATEDB', t); END IF;
+        IF r.rolcreaterole    THEN failures := failures || format('%s has CREATEROLE', t); END IF;
+        IF r.rolreplication   THEN failures := failures || format('%s has REPLICATION', t); END IF;
+        IF r.rolbypassrls     THEN failures := failures || format('%s has BYPASSRLS', t); END IF;
+
+        -- Every role connects and reads the schema, and none may create in it.
+        IF NOT has_database_privilege(t, db, 'CONNECT') THEN
+            failures := failures || format('%s cannot CONNECT to %s', t, db);
+        END IF;
+        IF has_database_privilege(t, db, 'CREATE') THEN
+            failures := failures || format('%s has CREATE on database %s', t, db);
+        END IF;
+        IF NOT has_schema_privilege(t, 'public', 'USAGE') THEN
+            failures := failures || format('%s lacks USAGE on schema public', t);
+        END IF;
+        IF has_schema_privilege(t, 'public', 'CREATE') THEN
+            failures := failures || format('%s has CREATE on schema public', t);
+        END IF;
+        -- No role may reach the drizzle migration ledger. Guarded because the
+        -- schema only exists once drizzle-kit has run; applying the migration
+        -- SQL by hand (as a throwaway verification DB does) leaves it absent.
+        IF to_regnamespace('drizzle') IS NOT NULL
+           AND has_schema_privilege(t, 'drizzle', 'USAGE') THEN
+            failures := failures || format('%s has USAGE on schema drizzle', t);
+        END IF;
+    END LOOP;
+
+    -- ── finance_app: DML on the core tables ───────────────────────────────
+    FOREACH t IN ARRAY ARRAY['accounts', 'account_types', 'account_type_categories',
+                             'transactions', 'transaction_categories',
+                             'transaction_types', 'account_balance_history']
+    LOOP
+        IF NOT has_table_privilege('finance_app', t, 'SELECT')
+           OR NOT has_table_privilege('finance_app', t, 'INSERT')
+           OR NOT has_table_privilege('finance_app', t, 'UPDATE')
+           OR NOT has_table_privilege('finance_app', t, 'DELETE') THEN
+            failures := failures || format('finance_app lacks full DML on %s', t);
+        END IF;
+        IF has_table_privilege('finance_app', t, 'TRUNCATE') THEN
+            failures := failures || format('finance_app can TRUNCATE %s', t);
+        END IF;
+    END LOOP;
+
+    -- users is read-only to the app.
+    IF NOT has_table_privilege('finance_app', 'users', 'SELECT') THEN
+        failures := failures || 'finance_app cannot SELECT users';
+    END IF;
+    FOREACH t IN ARRAY ARRAY['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE']
+    LOOP
+        IF has_table_privilege('finance_app', 'users', t) THEN
+            failures := failures || format('finance_app can %s users', t);
+        END IF;
+    END LOOP;
+
+    -- Views readable; serial sequences usable but not resettable (no setval).
+    FOREACH t IN ARRAY ARRAY['v_transactions_full', 'v_account_balances_current', 'v_daily_totals']
+    LOOP
+        IF NOT has_table_privilege('finance_app', t, 'SELECT') THEN
+            failures := failures || format('finance_app cannot SELECT %s', t);
+        END IF;
+    END LOOP;
+    IF NOT has_sequence_privilege('finance_app', txn_seq, 'USAGE')
+       OR NOT has_sequence_privilege('finance_app', acct_seq, 'USAGE') THEN
+        failures := failures || 'finance_app lacks USAGE on the serial sequences';
+    END IF;
+    IF has_sequence_privilege('finance_app', txn_seq, 'UPDATE') THEN
+        failures := failures || 'finance_app can setval the transactions sequence';
+    END IF;
+
+    -- ── finance_importer: append-only on transactions + lookup reads ──────
+    IF NOT has_table_privilege('finance_importer', 'transactions', 'SELECT')
+       OR NOT has_table_privilege('finance_importer', 'transactions', 'INSERT') THEN
+        failures := failures || 'finance_importer cannot SELECT+INSERT transactions';
+    END IF;
+    FOREACH t IN ARRAY ARRAY['UPDATE', 'DELETE', 'TRUNCATE']
+    LOOP
+        IF has_table_privilege('finance_importer', 'transactions', t) THEN
+            failures := failures || format('finance_importer can %s transactions', t);
+        END IF;
+    END LOOP;
+    FOREACH t IN ARRAY ARRAY['accounts', 'transaction_categories', 'transaction_types']
+    LOOP
+        IF NOT has_table_privilege('finance_importer', t, 'SELECT') THEN
+            failures := failures || format('finance_importer cannot SELECT %s', t);
+        END IF;
+        IF has_table_privilege('finance_importer', t, 'INSERT') THEN
+            failures := failures || format('finance_importer can INSERT %s', t);
+        END IF;
+    END LOOP;
+    FOREACH t IN ARRAY ARRAY['users', 'account_balance_history', 'account_types',
+                             'v_transactions_full']
+    LOOP
+        IF has_table_privilege('finance_importer', t, 'SELECT') THEN
+            failures := failures || format('finance_importer can SELECT %s', t);
+        END IF;
+    END LOOP;
+    IF NOT has_sequence_privilege('finance_importer', txn_seq, 'USAGE') THEN
+        failures := failures || 'finance_importer lacks USAGE on the transactions sequence';
+    END IF;
+    IF has_sequence_privilege('finance_importer', acct_seq, 'USAGE') THEN
+        failures := failures || 'finance_importer has USAGE on the accounts sequence';
+    END IF;
+
+    -- ── finance_metabase: the three views, nothing else ───────────────────
+    FOREACH t IN ARRAY ARRAY['v_transactions_full', 'v_account_balances_current', 'v_daily_totals']
+    LOOP
+        IF NOT has_table_privilege('finance_metabase', t, 'SELECT') THEN
+            failures := failures || format('finance_metabase cannot SELECT %s', t);
+        END IF;
+        IF has_table_privilege('finance_metabase', t, 'INSERT') THEN
+            failures := failures || format('finance_metabase can INSERT %s', t);
+        END IF;
+    END LOOP;
+    FOREACH t IN ARRAY ARRAY['transactions', 'accounts', 'account_types',
+                             'account_type_categories', 'transaction_categories',
+                             'transaction_types', 'account_balance_history', 'users']
+    LOOP
+        IF has_table_privilege('finance_metabase', t, 'SELECT') THEN
+            failures := failures || format('finance_metabase can SELECT base table %s', t);
+        END IF;
+    END LOOP;
+
+    -- ── PUBLIC holds nothing on this database ─────────────────────────────
+    IF has_database_privilege('public', db, 'CONNECT') THEN
+        failures := failures || format('PUBLIC still has CONNECT on %s', db);
+    END IF;
+    IF has_schema_privilege('public', 'public', 'CREATE') THEN
+        failures := failures || 'PUBLIC still has CREATE on schema public';
+    END IF;
+
+    IF array_length(failures, 1) > 0 THEN
+        RAISE EXCEPTION E'grant matrix violations in %:\n  - %',
+            db, array_to_string(failures, E'\n  - ');
+    END IF;
+
+    RAISE NOTICE 'grant matrix OK for % (finance_app, finance_importer, finance_metabase)', db;
+END
+$$;

--- a/scripts/verify-db-roles.sh
+++ b/scripts/verify-db-roles.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Verifies the least-privilege service roles (Issue #130).
+#
+# Two layers, because neither alone is sufficient:
+#
+#   1. Catalog gate — runs init-db/roles/assert-grants.sql, which asserts the
+#      full grant matrix (positively and negatively) against the system catalog.
+#   2. Behavioural smoke — connects as each role over a password-authenticated
+#      TCP connection and runs real statements, asserting the allowed ones
+#      succeed and the forbidden ones fail. This is what proves the mechanic the
+#      matrix cannot: finance_metabase reads the views while having no privilege
+#      whatsoever on their base tables (the views are not security_invoker, so
+#      they execute with the view owner's rights).
+#
+# Writes are wrapped in BEGIN … ROLLBACK, so this is safe to run against a
+# populated database — but point it at Finances_Test by default.
+#
+# Used by the "role privilege gate" step in .github/workflows/ci.yml, and
+# runnable by hand against the live stack — the migrate service already carries
+# every variable this needs, so no -e flags are required:
+#
+#   docker compose run --rm --entrypoint bash migrate /scripts/verify-db-roles.sh Finances
+#
+# Environment (all supplied by the migrate service in docker-compose.yml):
+#   PGHOST/PGPORT/PGUSER/PGPASSWORD  superuser connection (for the catalog gate)
+#   FINANCE_APP_DB_PASSWORD          finance_app password       (required)
+#   FINANCE_IMPORTER_DB_PASSWORD     finance_importer password  (required)
+#   FINANCE_METABASE_DB_PASSWORD     finance_metabase password  (required)
+#   ROLES_DIR                        location of the roles SQL  (default: /roles)
+#
+# Note: connections must NOT arrive over a pg_hba `trust` rule or the password
+# half of this check is vacuous — inside the postgres container, 127.0.0.1 is
+# trusted, so pass PGHOST as the service name / container IP instead.
+# ------------------------------------------------------------
+set -uo pipefail
+
+DB="${1:-Finances_Test}"
+ROLES_DIR="${ROLES_DIR:-/roles}"
+
+: "${FINANCE_APP_DB_PASSWORD:?must be set}"
+: "${FINANCE_IMPORTER_DB_PASSWORD:?must be set}"
+: "${FINANCE_METABASE_DB_PASSWORD:?must be set}"
+
+failed=0
+
+echo "==> Catalog gate: assert-grants.sql against ${DB}"
+if ! psql -v ON_ERROR_STOP=1 -d "$DB" -f "${ROLES_DIR}/assert-grants.sql"; then
+  echo "FAIL  grant matrix assertions did not pass"
+  failed=1
+fi
+
+echo
+echo "==> Behavioural smoke: connecting as each role"
+
+# expect <role> <password> allow|deny <label> <sql>
+#
+# Asserts on whether the statement was refused for lack of privilege, not on
+# whether it merely failed. Postgres evaluates privileges before it executes, so
+# a denial is data-independent — which keeps this check meaningful against an
+# empty Finances (a fresh database has lookup rows but no accounts, so an INSERT
+# into transactions legitimately trips a NOT NULL constraint that says nothing
+# about the grant under test).
+#
+# Detection keys on SQLSTATE 42501 (insufficient_privilege), surfaced by
+# VERBOSITY=verbose, rather than on the message text — the wording differs
+# between a plain refusal ("permission denied for table users") and an ownership
+# one ("must be owner of table transactions"), and the text is localized while
+# the code is not.
+expect() {
+  local role="$1" pass="$2" mode="$3" label="$4" sql="$5" out
+  out="$(PGPASSWORD="$pass" psql -U "$role" -d "$DB" \
+        -v ON_ERROR_STOP=1 -v VERBOSITY=verbose -qtAc "$sql" 2>&1)"
+
+  local denied=0
+  case "$out" in
+    *"ERROR:  42501"*) denied=1 ;;
+  esac
+
+  if [ "$mode" = allow ] && [ "$denied" -eq 1 ]; then
+    echo "FAIL  ${role} must be able to: ${label}"
+    echo "      ${out}"
+    failed=1
+  elif [ "$mode" = deny ] && [ "$denied" -eq 0 ]; then
+    echo "FAIL  ${role} must NOT be able to: ${label}"
+    echo "      expected a permission-denied error, got: ${out:-(statement succeeded)}"
+    failed=1
+  else
+    echo "ok    ${role} ${mode}: ${label}"
+  fi
+}
+
+# Derives account/type/category from existing rows so this works against any
+# seeded database. Rolled back, so no row is ever actually committed.
+INSERT_TXN="INSERT INTO transactions
+  (transaction_description, transaction_date, account_id, amount,
+   transaction_type_id, transaction_category_id)
+  SELECT 'privilege-smoke', CURRENT_DATE, min(a.account_id), 1.00,
+         (SELECT min(transaction_type_id) FROM transaction_types),
+         (SELECT min(transaction_category_id) FROM transaction_categories)
+  FROM accounts a"
+
+READ_VIEWS="SELECT (SELECT count(*) FROM v_transactions_full)
+                 + (SELECT count(*) FROM v_account_balances_current)
+                 + (SELECT count(*) FROM v_daily_totals)"
+
+# ── finance_app — DML on the core tables, read-only on users, no DDL ──────
+expect finance_app "$FINANCE_APP_DB_PASSWORD" allow "INSERT a transaction"     "BEGIN; ${INSERT_TXN}; ROLLBACK"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" allow "DELETE balance history"   "BEGIN; DELETE FROM account_balance_history; ROLLBACK"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" allow "SELECT the three views"   "$READ_VIEWS"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" allow "SELECT users"             "SELECT count(*) FROM users"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" deny  "INSERT a user"            "BEGIN; INSERT INTO users (username, password_hash) VALUES ('smoke','x'); ROLLBACK"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" deny  "UPDATE users"             "BEGIN; UPDATE users SET role = 'admin'; ROLLBACK"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" deny  "TRUNCATE transactions"    "BEGIN; TRUNCATE transactions CASCADE; ROLLBACK"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" deny  "CREATE TABLE"             "CREATE TABLE privilege_smoke_escalation (id int)"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" deny  "DROP TABLE transactions"  "BEGIN; DROP TABLE transactions CASCADE; ROLLBACK"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" deny  "CREATE ROLE"              "CREATE ROLE privilege_smoke_escalation LOGIN"
+expect finance_app "$FINANCE_APP_DB_PASSWORD" deny  "setval a sequence"        "SELECT setval(pg_get_serial_sequence('transactions','transaction_id'), 1)"
+
+# ── finance_importer — append-only on transactions, lookup reads only ─────
+expect finance_importer "$FINANCE_IMPORTER_DB_PASSWORD" allow "INSERT a transaction" "BEGIN; ${INSERT_TXN}; ROLLBACK"
+expect finance_importer "$FINANCE_IMPORTER_DB_PASSWORD" allow "SELECT the lookup maps" \
+  "SELECT (SELECT count(*) FROM accounts) + (SELECT count(*) FROM transaction_categories) + (SELECT count(*) FROM transaction_types)"
+expect finance_importer "$FINANCE_IMPORTER_DB_PASSWORD" deny  "UPDATE transactions"  "BEGIN; UPDATE transactions SET amount = 0; ROLLBACK"
+expect finance_importer "$FINANCE_IMPORTER_DB_PASSWORD" deny  "DELETE transactions"  "BEGIN; DELETE FROM transactions; ROLLBACK"
+expect finance_importer "$FINANCE_IMPORTER_DB_PASSWORD" deny  "SELECT users"         "SELECT count(*) FROM users"
+expect finance_importer "$FINANCE_IMPORTER_DB_PASSWORD" deny  "SELECT a view"        "SELECT count(*) FROM v_transactions_full"
+
+# ── finance_metabase — the three views and nothing else ──────────────────
+expect finance_metabase "$FINANCE_METABASE_DB_PASSWORD" allow "SELECT the three views"       "$READ_VIEWS"
+expect finance_metabase "$FINANCE_METABASE_DB_PASSWORD" deny  "SELECT base table transactions" "SELECT count(*) FROM transactions"
+expect finance_metabase "$FINANCE_METABASE_DB_PASSWORD" deny  "SELECT base table accounts"     "SELECT count(*) FROM accounts"
+expect finance_metabase "$FINANCE_METABASE_DB_PASSWORD" deny  "SELECT users"                   "SELECT count(*) FROM users"
+expect finance_metabase "$FINANCE_METABASE_DB_PASSWORD" deny  "INSERT a transaction"           "BEGIN; ${INSERT_TXN}; ROLLBACK"
+
+echo
+if [ "$failed" -ne 0 ]; then
+  echo "role privilege verification FAILED for ${DB}"
+  exit 1
+fi
+echo "role privilege verification passed for ${DB}"


### PR DESCRIPTION
## Summary

Closes #130.

Binds the Postgres (`5433`) and Metabase (`3000`) host ports to `127.0.0.1`, and replaces the shared `postgres` superuser with three least-privilege login roles — one per long-running service.

| Role | Gets | Notably cannot |
|---|---|---|
| `finance_app` | DML on all tables, `SELECT` on the views and sequences | write `users`, any DDL, `TRUNCATE`, `setval` |
| `finance_importer` | `SELECT`+`INSERT` on `transactions`, lookup reads | `UPDATE`/`DELETE` anything, read `users` or the views |
| `finance_metabase` | `SELECT` on the three views | touch any base table |

Tables stay owned by `POSTGRES_USER`, so no service role can alter, drop, or truncate the schema, create roles or databases, or reach the `drizzle` ledger. The superuser is retained only for the maintenance jobs that need DDL or cluster-wide reads (`migrate`, `init-script`, `pg-backup`) — none network-facing.

### Decisions worth reviewing

- **Roles/grants live in the `migrate` service, not `init-db/01-create-databases.sh`** (which the issue named). That script only runs on an empty data directory, so an existing volume would never gain the roles; and a `GRANT` names tables, so it can only run after migrations create them. `migrate` is already idempotent, already loops both databases, and already gates the app and importer via `service_completed_successfully`.
- **`users` is `SELECT`-only to `finance_app`.** No app code writes it — accounts are created by `npm run auth:create-user` — so an app-level compromise cannot mint an admin. Cost: that CLI must now run with the `postgres` connection string (documented in `docs/auth.md`).
- **Port 3001 is unchanged.** Only 5433 and 3000 move to loopback, matching the issue's Proposal. 3001 is the surface meant to be reachable; exposing it safely is #182.
- **`finance_app` is granted broadly then revoked** (`GRANT … ON ALL TABLES`, then `REVOKE … ON users`) plus `ALTER DEFAULT PRIVILEGES`, so a table added by a future migration is covered automatically. The two narrow roles are enumerated, so a migration adding a table *they* need requires editing `02-grants.sql` — which is what the new CI gate catches.
- **`/api/health` was not split** into a liveness probe + seed-data endpoint (raised in the #130 comment). #130 *reduces* exposure rather than increasing it, so the probe-cost concern is really #182's. Worth its own issue.

### Deviation from the issue

Step 3 of the proposal ("point each service's connection string at its role in `docker-compose.yml`") **cannot be done for Metabase.** Metabase stores analytics connections in its own metadata database, not in env — `MB_DB_*` configures only its internal metadata DB, which already used a non-superuser role. Pointing it at `finance_metabase` is a one-time manual step in the admin UI, documented in [docs/database.md](../blob/issue-130-postgres-lockdown/docs/database.md#pointing-metabase-at-finance_metabase).

### Breaking configuration change

`FINANCE_APP_DB_PASSWORD`, `FINANCE_IMPORTER_DB_PASSWORD`, and `FINANCE_METABASE_DB_PASSWORD` must be added to `.env` — `migrate` aborts with a pointer to `.env.example` rather than create a login role with a blank password. Existing databases are upgraded in place on the next `docker compose up`; no manual SQL, no data migration.

## Checklist

- [x] **Links an issue** — closes #130; commit uses `Issue #130 - <short imperative>`.
- [x] **CHANGELOG.md updated** — `Security` bullet for the lockdown, `Changed` bullet flagging the required new `.env` keys.
- [x] **CI gates green** — schema-drift, seed-reference, changelog, lint, unit (231) and integration (87) all pass; adds a fourth gate (role privileges).
- [x] **Schema change?** — N/A, no `schema.ts` edits. Grants are applied at runtime, not via a migration, since they are per-deployment configuration rather than schema.
- [x] **Tests** — new `scripts/verify-db-roles.sh` (catalog matrix + behavioural smoke as each role), wired into CI. Existing suites unchanged.

## Notes

### Verification

Ran the full stack on an isolated Compose project (fresh volume, renamed containers) so the real `Finances` data was never touched:

- `/api/health` returned 200 with the app connected as `finance_app`; the importer connected as `finance_importer` and loaded its 60 reference rows.
- **AC #1** — `ss` shows `127.0.0.1:5433`; a connect to the host's LAN address is refused, loopback succeeds.
- **AC #2** — the grant gate passes on both `Finances` and `Finances_Test`.
- **AC #3** — 23 behavioural assertions across the three roles, over password-authenticated TCP.
- Negative control: widening a grant by hand fails *both* layers of the gate and exits 1; re-running `migrate` converges it back.
- Password rotation via `.env` takes effect (old rejected, new accepted); a missing password aborts `migrate` with the intended message.
- Simulated the new CI steps verbatim from `app/` to check the relative paths.

Two things I could not verify: reachability from the Windows side of WSL2 (loopback forwarding *should* keep `localhost:5433` working), and app writes through the browser UI — those paths are covered instead by real `INSERT`/`DELETE` statements executed as `finance_app` in the smoke.

### Why the gate keys on SQLSTATE

Two bugs found while building the check, both worth knowing if you touch it:

1. Asserting on *statement failure* misreports a `NOT NULL` violation as a privilege failure — a fresh `Finances` has lookup rows but no accounts. Privileges are evaluated before execution, so keying on refusal instead makes the check data-independent.
2. Pinning `lc_messages=C` to stabilise the message text fails: it is a superuser-only GUC, so the non-superuser roles were refused at connect time and *every* assertion "passed". It now matches `SQLSTATE 42501`, which is neither localized nor superuser-gated.

### Follow-ups

- #189 — `POSTGRES_PASSWORD` and `MB_DB_PASS` are not rotatable from `.env` (they only apply at `initdb`), unlike the three roles added here. Found while writing the rotation docs.
- Splitting `/api/health` into a liveness probe + `/api/health/seed-data` — not yet filed; see the decision above.
