### PR TITLE
Issue #237 - Add the nonce-based CSP follow-up to the Phase 3 roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,6 +104,7 @@ merges.
 - [#193](https://github.com/aellington89/finance-stack/issues/193) Adopt `react-hooks/set-state-in-effect`; drop the `eslint-plugin-react-hooks` pin *(new — from #131)*
 - [#195](https://github.com/aellington89/finance-stack/issues/195) Run `npm run typecheck` in CI *(new — from #131)*
 - [#232](https://github.com/aellington89/finance-stack/issues/232) Wire an error-tracking backend into `reportError()` *(new — from #129)*
+- [#237](https://github.com/aellington89/finance-stack/issues/237) Nonce-based CSP: remove `'unsafe-inline'` from `script-src` and `style-src` *(new — from #182)*
 
 ### v1.2.0 — Phase 4 (Performance polish)
 - [#125](https://github.com/aellington89/finance-stack/issues/125) Suspense + loading.tsx + not-found.tsx


### PR DESCRIPTION
## Summary

Records [#237](https://github.com/aellington89/finance-stack/issues/237) (nonce-based CSP,
the deferred follow-up from #182) under **v1.1.0 — Phase 3** in `docs/roadmap.md`, with the
`*(new — from #182)*` provenance marker that #232, #193 and #195 already use.

One line. Docs-only.

Refs #237, #182.

## Checklist

- [x] **Links an issue** — refs #237; commit uses the `Issue #N -` format.
- [x] **CHANGELOG.md updated** — *N/A, docs-only.*
- [x] **CI gates green**
- [x] **Schema change?** — N/A.
- [x] **Tests** — N/A, docs-only.

## Notes

**`#182`'s entry under v0.2.0 is deliberately left alone.** I had flagged it as needing an
update, and that was wrong: `*(new)*` marks an issue *added to the milestone after the
roadmap was first drafted*, not one still outstanding. #179, #180 and #187 are all closed and
still carry it, so stripping it from #182 alone would have made the file less consistent, not
more.

### Two things noticed while checking, not changed here

- **#186** ("List all docs/ guides in the docs README Guides section") appears to be
  satisfied — the #182 PR added `deployment.md`, `backups.md` and `roadmap.md` to
  `docs/README.md`, and all 13 files in `docs/` are now listed. Worth verifying and closing.
- **#100** (the security epic) is closed, but its roadmap line still reads
  *"closes when its children do"* while #181, #186, #189, #191 and #194 remain open under
  Phase 1. Left as-is — that's a call about the epic, not about this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
