### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-15
+
 ### Added
 
 - **A role gate on the two lookup tables every KPI is computed from, and an admin screen to manage them.** `account_type_categories` and `transaction_types` define the balance-sheet groupings and the transaction classification the dashboard, accounting and work-expense views all report on, so a wrong edit there is not one bad row — it is every view at once. `users.role` had existed since [#120](https://github.com/aellington89/finance-stack/issues/120) with a default of `admin` and **nothing gated on it**; it is now a two-value vocabulary (`admin`, `user`) with a `CHECK` constraint, a new `requireAdminUser()` guard composing the existing session-and-rate-limit one, a new admin-only `/settings/admin` page carrying both tables, and a `--role admin|user` flag on `npm run auth:create-user`. All six mutators across the two tables sit behind the gate. `createTransactionType` — deleted outright by [#109](https://github.com/aellington89/finance-stack/issues/109) — is restored behind it, which is exactly where that issue said a legitimate insert belonged, taking the mutating-action count in [docs/input-validation.md](docs/input-validation.md) back from 17 to 18.
@@ -213,7 +215,8 @@ Earlier alpha history (v0.1.0-alpha.1 – v0.1.0-alpha.5) is recorded in the
 [Alpha Development History](https://github.com/aellington89/finance-stack/wiki/Alpha-Development-History)
 wiki page.
 
-[Unreleased]: https://github.com/aellington89/finance-stack/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/aellington89/finance-stack/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/aellington89/finance-stack/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/aellington89/finance-stack/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/aellington89/finance-stack/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/aellington89/finance-stack/compare/v0.1.3...v0.1.4

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-stack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-stack",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@base-ui/react": "^1.7.0",
         "@tanstack/react-table": "^9.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-stack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3001",


### PR DESCRIPTION
Cuts **v0.3.0**. Closes the `[Unreleased]` section as `## [0.3.0] - 2026-08-15`, opens a fresh empty `[Unreleased]`, updates the reference links, and bumps `app/package.json` to `0.3.0` via `npm version --no-git-tag-version` (so `package-lock.json` stays in step).

## What's in it

Four issues, all already written up in `CHANGELOG.md`:

- **[#87](https://github.com/aellington89/finance-stack/issues/87)** — role gate on `account_type_categories` and `transaction_types`, a new admin-only `/settings/admin`, `requireAdminUser()`, and a `--role` flag on `auth:create-user`. The role is read from the database per guarded call rather than from the 30-day JWT.
- **[#111](https://github.com/aellington89/finance-stack/issues/111)** — `transaction_categories.reporting_role`, replacing the hard-coded fifteen-id liability lists, so a fresh install and user-added loan categories both feed the Liabilities aggregates. Arithmetic deliberately unchanged; migration `0005` backfills on id+name.
- **[#109](https://github.com/aellington89/finance-stack/issues/109)** — lookup rows the app ships are protected against rename/delete; Transaction Type creation dropped from `/settings/categories` (restored behind the admin gate by #87).
- **[#178](https://github.com/aellington89/finance-stack/issues/178)** — the seed-data taxonomy, `transaction_categories` id 6 `Other` now shipping in `shared-lookups.sql`, and the fixture-agreement gate.

Routine Dependabot bumps in the range are not given changelog entries, consistent with prior releases. #274 was roadmap-doc-only.

## Verified locally

| Gate | Result |
| --- | --- |
| `check:changelog` (incl. `-- v0.3.0` tag form) | ✅ |
| `check:docs` | ✅ 14 guides indexed |
| `check:seed-references` (all 6 assertions) | ✅ |
| Schema drift (`drizzle-kit generate`) | ✅ nothing to migrate |
| Role privilege gate (`verify-db-roles.sh Finances_Test`) | ✅ |
| `npm audit --omit=dev` / full tree, `--audit-level=high` | ✅ moderate only |
| `lint` / `typecheck` | ✅ |
| `test:unit` | ✅ 450 passed |
| `test:integration` | ✅ 264 passed |

Image scan gate not run locally — it runs in the parallel `image` job.

## After merge

Tag the release commit on `master` and push, which is what actually publishes:

```sh
git tag -a v0.3.0 -m "v0.3.0 — Admin role gate on the KPI lookup tables; reporting roles for liability aggregates"
git push origin v0.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
