### PR TITLE
Route Dependabot version + security updates to the patch integration branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@
 #
 # Deliberately not configured: auto-merge (out of scope per Issue #131).
 # Every bump gets reviewed and must pass the full gate suite.
+#
+# Every entry below sets `target-branch: patch`: version-update PRs open against
+# the long-lived `patch` integration branch instead of the default branch, so a
+# week's bumps collect there to be reviewed and gated together, then merged to
+# the default branch as one change. Dependabot still reads this config from the
+# default branch — `target-branch` only redirects where PRs are opened — so the
+# `patch` branch must exist (cut from the default branch) or Dependabot errors,
+# and this file must be on the default branch for the setting to take effect.
+# Note that Dependabot *security* updates ignore `target-branch` and still open
+# against the default branch.
 
 version: 2
 
@@ -18,6 +28,7 @@ updates:
   # package.json, no workspaces).
   - package-ecosystem: npm
     directory: /app
+    target-branch: patch
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -101,6 +112,7 @@ updates:
   # Importer service Python dependencies (importer/requirements.txt).
   - package-ecosystem: pip
     directory: /importer
+    target-branch: patch
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -114,6 +126,7 @@ updates:
   # different runtime than the image ships (Issue #210).
   - package-ecosystem: docker
     directory: /app
+    target-branch: patch
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -124,6 +137,7 @@ updates:
   # tracked.
   - package-ecosystem: docker
     directory: /importer
+    target-branch: patch
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -135,6 +149,7 @@ updates:
   # backup-smoke.yml. Do not merge it on its own — see scripts/Dockerfile.
   - package-ecosystem: docker
     directory: /scripts
+    target-branch: patch
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -148,6 +163,7 @@ updates:
   # separate ecosystem and will not group with this PR.
   - package-ecosystem: docker-compose
     directory: /
+    target-branch: patch
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -173,6 +189,7 @@ updates:
   # maintainable rather than a one-off snapshot.
   - package-ecosystem: github-actions
     directory: /
+    target-branch: patch
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-retarget.yml
+++ b/.github/workflows/dependabot-retarget.yml
@@ -1,0 +1,47 @@
+# Retargets Dependabot PRs onto the `patch` integration branch.
+#
+# `target-branch: patch` in .github/dependabot.yml only redirects Dependabot
+# *version* updates. Dependabot *security* updates (raised from Dependabot
+# alerts) always open against the default branch, and no config key changes
+# that. This workflow closes the gap: any Dependabot PR opened against `master`
+# is moved onto `patch`, so security updates land in the same batched, gated
+# flow as every other bump.
+#
+# `pull_request_target` — not `pull_request` — is required. Workflows that
+# Dependabot triggers on `pull_request` receive a read-only GITHUB_TOKEN and so
+# cannot change a PR's base; `pull_request_target` is not on that restricted
+# list and runs in the base-repo context with the token this file grants. It is
+# safe here because the job checks out no PR code and only calls the API — the
+# `pull_request_target` hazard (running untrusted PR code under a privileged
+# token) does not arise. The token is scoped to `pull-requests: write` and
+# nothing else.
+#
+# Like dependabot.yml, this only takes effect once it is on the default branch:
+# `pull_request_target` runs the workflow version from the PR's base branch, and
+# security PRs are based on the default branch. In steady state — dependabot.yml
+# already merged — the only Dependabot PRs reaching `master` are security
+# updates, which is exactly what this retargets.
+
+name: Retarget Dependabot PRs to patch
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retarget:
+    # Only Dependabot's own PRs, and only those aimed at the default branch —
+    # never touch a base a human chose on purpose.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move base branch to patch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR_URL" --base patch


### PR DESCRIPTION
## Summary

Routes Dependabot updates at a long-lived `patch` integration branch instead of `master`, so a week's bumps collect on one branch to be reviewed and gated together, then merged to `master` as a single change.

- **Version updates** — `target-branch: patch` added to all seven `updates:` entries in `.github/dependabot.yml` (npm, pip, 3× docker, docker-compose, github-actions), plus a header comment explaining the mechanism.
- **Security updates** — `target-branch` does **not** apply to Dependabot security updates; they always open against the default branch by design, and no config key changes that. A new workflow, `.github/workflows/dependabot-retarget.yml`, moves any Dependabot PR opened against `master` onto `patch` so security updates flow through the same path. It uses `pull_request_target` (the `pull_request` token Dependabot gets is read-only and cannot change a PR base), checks out no PR code, and scopes the token to `pull-requests: write`.

Both changes only take effect once merged here — Dependabot reads its config, and `pull_request_target` runs its workflow, from the default branch.

The three currently-open Dependabot PRs (#305, #306, #307) have already been retargeted onto `patch`.

No tracking issue — this is an infrastructure/chore change.

## Checklist

- [x] **Links an issue** — N/A: no tracking issue (CI/config chore). Commits use a descriptive imperative subject rather than the `Issue #N -` prefix for the same reason.
- [x] **CHANGELOG.md updated** — N/A: chore-only, not user-visible.
- [x] **CI gates green** — to be confirmed by CI on this PR.
- [x] **Schema change?** — none.
- [x] **Tests** — N/A: config/workflow change with no unit-testable surface.

## Notes

- `patch` was branched off `master` at v1.0.0 and will drift over time — merge `master` into `patch` periodically, and before cutting a release.
- After merge, the only Dependabot PRs reaching `master` are security updates (which the workflow retargets); version updates open directly on `patch`.
- Manual companion bumps called out in `CONTRIBUTING.md` — the `postgres:` pins in `ci.yml`/`backup-smoke.yml` and node-version pins Dependabot doesn't read — still apply, now landing on `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWKTCbfRAa2bxijnuCbVzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWKTCbfRAa2bxijnuCbVzt)_